### PR TITLE
fix: refresh SCSS reference count code lenses

### DIFF
--- a/.changeset/codelens-refresh.md
+++ b/.changeset/codelens-refresh.md
@@ -1,0 +1,5 @@
+---
+"css-module-explainer": patch
+---
+
+Refresh SCSS reference count code lenses when semantic reference data changes so reference counts stay in sync after source analysis.

--- a/server/src/composition-root.ts
+++ b/server/src/composition-root.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import type { MessageReader, MessageWriter } from "vscode-languageserver/node";
 import {
+  CodeLensRefreshRequest,
   createConnection,
   DidChangeWatchedFilesNotification,
   ProposedFeatures,
@@ -108,6 +109,7 @@ export function createServer(options: CreateServerOptions): CreatedServer {
   let bundle: ProviderDeps | null = null;
   let watchedFilesDisposable: Promise<{ dispose(): void }> | null = null;
   let clientSupportsDynamicWatchers = false;
+  let clientSupportsCodeLensRefresh = false;
 
   // ── Lifecycle ──────────────────────────────────────────────
 
@@ -116,7 +118,15 @@ export function createServer(options: CreateServerOptions): CreatedServer {
     const workspaceRoot = resolveWorkspaceRoot(params);
     clientSupportsDynamicWatchers =
       params.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration ?? false;
-    bundle = buildBundle(workspaceRoot, options, connection, documents);
+    clientSupportsCodeLensRefresh =
+      params.capabilities.workspace?.codeLens?.refreshSupport ?? false;
+    bundle = buildBundle(
+      workspaceRoot,
+      options,
+      connection,
+      documents,
+      clientSupportsCodeLensRefresh,
+    );
     return {
       capabilities: buildCapabilities(),
       serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
@@ -194,7 +204,15 @@ function buildBundle(
   options: CreateServerOptions,
   connection: Connection,
   documents: TextDocuments<TextDocument>,
+  supportsCodeLensRefresh: boolean,
 ): ProviderDeps {
+  const refreshCodeLens = (): void => {
+    if (!supportsCodeLensRefresh) return;
+    // Clients advertise support via `workspace.codeLens.refreshSupport`.
+    // Unsupported clients may reject the request; swallow that rather
+    // than surfacing noisy transport errors.
+    void connection.sendRequest(CodeLensRefreshRequest.type).catch(() => {});
+  };
   const caches = buildCaches();
   const typeResolver = buildTypeResolver(options);
   const readStyleFile = options.readStyleFile ?? defaultReadStyleFile;
@@ -212,6 +230,7 @@ function buildBundle(
     typeResolver,
     fileExists,
     getAliasResolver: () => aliasHolder.get(),
+    refreshCodeLens,
   });
   const indexerWorker = buildIndexerWorker(
     options,
@@ -240,6 +259,7 @@ function buildBundle(
       caches.styleIndexCache.setMode(mode);
       caches.semanticReferenceIndex.clear();
     },
+    refreshCodeLens,
   };
 }
 
@@ -297,6 +317,7 @@ interface AnalysisCacheArgs {
   readonly typeResolver: TypeResolver;
   readonly fileExists: (path: string) => boolean;
   readonly getAliasResolver: () => AliasResolver;
+  readonly refreshCodeLens: () => void;
 }
 
 function buildAnalysisCache(args: AnalysisCacheArgs): DocumentAnalysisCache {
@@ -307,6 +328,7 @@ function buildAnalysisCache(args: AnalysisCacheArgs): DocumentAnalysisCache {
     typeResolver,
     fileExists,
     getAliasResolver,
+    refreshCodeLens,
   } = args;
   return new DocumentAnalysisCache({
     sourceFileCache: caches.sourceFileCache,
@@ -333,6 +355,7 @@ function buildAnalysisCache(args: AnalysisCacheArgs): DocumentAnalysisCache {
         semanticContribution.referenceSites,
         semanticContribution.moduleUsages,
       );
+      refreshCodeLens();
     },
   });
 }

--- a/server/src/handler-registration.ts
+++ b/server/src/handler-registration.ts
@@ -88,6 +88,7 @@ function registerSettingsHandler(state: HandlerState): () => void {
         if (aliasChanged || modeChanged) {
           deps.analysisCache.clear();
           deps.semanticReferenceIndex.clear();
+          deps.refreshCodeLens();
           for (const doc of state.ctx.documents.all()) {
             const filePath = fileUrlToPath(doc.uri);
             if (findLangForPath(filePath)) {
@@ -208,6 +209,7 @@ function registerDocumentHandlers(state: HandlerState): void {
     // before the next analyze or unused-selector check runs.
     deps.semanticReferenceIndex.forget(change.document.uri);
     deps.analysisCache.invalidate(change.document.uri);
+    deps.refreshCodeLens();
   });
 }
 

--- a/server/src/providers/provider-deps.ts
+++ b/server/src/providers/provider-deps.ts
@@ -98,6 +98,11 @@ export interface ProviderDeps {
    * contract.
    */
   setClassnameTransform(mode: ClassnameTransformMode): void;
+  /**
+   * Ask the client to refresh visible CodeLens entries after the
+   * semantic reference graph changes.
+   */
+  refreshCodeLens(): void;
 }
 
 /** No-op logError stub for tests — keeps `ProviderDeps.logError` required. */

--- a/test/protocol/_harness/in-process-server.ts
+++ b/test/protocol/_harness/in-process-server.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 import {
   CodeActionRequest,
   CodeLensRequest,
+  CodeLensRefreshRequest,
   CompletionRequest,
   createProtocolConnection,
   DefinitionRequest,
@@ -116,6 +117,7 @@ export interface LspTestClient {
    * debounced push-based diagnostics pipeline .
    */
   waitForDiagnostics(uri: string, timeoutMs?: number): Promise<Diagnostic[]>;
+  waitForCodeLensRefresh(timeoutMs?: number): Promise<void>;
   prepareRename(
     params: PrepareRenameParams,
   ): Promise<{ range: LspRange; placeholder: string } | null>;
@@ -203,6 +205,8 @@ export function createInProcessServer(options: InProcessServerOptions = {}): Lsp
     string,
     Array<{ resolve: (d: Diagnostic[]) => void; reject: (e: unknown) => void }>
   >();
+  let pendingCodeLensRefreshes = 0;
+  const codeLensRefreshWaiters: Array<{ resolve: () => void; reject: (e: unknown) => void }> = [];
   // Handle workspace/configuration requests from the server. The
   // server's `fetchSettings` asks for two sections
   // (`cssModuleExplainer` + `cssModules`) in separate requests, so
@@ -227,6 +231,15 @@ export function createInProcessServer(options: InProcessServerOptions = {}): Lsp
     queue.push(mapped);
     pendingDiagnostics.set(mapped.uri, queue);
   });
+  client.onRequest(CodeLensRefreshRequest.type, async () => {
+    if (codeLensRefreshWaiters.length > 0) {
+      const waiter = codeLensRefreshWaiters.shift()!;
+      waiter.resolve();
+    } else {
+      pendingCodeLensRefreshes += 1;
+    }
+    return undefined;
+  });
   client.listen();
 
   return {
@@ -234,7 +247,11 @@ export function createInProcessServer(options: InProcessServerOptions = {}): Lsp
       const base: InitializeParams = {
         processId: process.pid,
         rootUri: workspaceUri,
-        capabilities: {},
+        capabilities: {
+          workspace: {
+            codeLens: { refreshSupport: true },
+          },
+        },
         workspaceFolders: [{ uri: workspaceUri, name: "fake" }],
       };
       return client.sendRequest(InitializeRequest.type, {
@@ -297,6 +314,29 @@ export function createInProcessServer(options: InProcessServerOptions = {}): Lsp
         remapWorkspaceUris(params, LEGACY_WORKSPACE_URI, workspaceUri),
       );
       return remapWorkspaceUris(result, workspaceUri, LEGACY_WORKSPACE_URI);
+    },
+    async waitForCodeLensRefresh(timeoutMs = 1500) {
+      if (pendingCodeLensRefreshes > 0) {
+        pendingCodeLensRefreshes -= 1;
+        return;
+      }
+      return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const index = codeLensRefreshWaiters.findIndex((waiter) => waiter.resolve === resolve);
+          if (index >= 0) codeLensRefreshWaiters.splice(index, 1);
+          reject(new Error(`waitForCodeLensRefresh timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        codeLensRefreshWaiters.push({
+          resolve: () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          reject: (e) => {
+            clearTimeout(timer);
+            reject(e);
+          },
+        });
+      });
     },
     async prepareRename(params) {
       const result = await client.sendRequest(

--- a/test/protocol/code-lens-refresh.test.ts
+++ b/test/protocol/code-lens-refresh.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "../_fixtures/protocol";
+import { FakeTypeResolver } from "../_fixtures/fake-type-resolver";
+
+test("SCSS code lens refreshes after TSX semantic references are analyzed", async ({
+  makeClient,
+}) => {
+  const scssUri = "file:///fake/workspace/src/Some.module.scss";
+  const tsxUri = "file:///fake/workspace/src/Some.tsx";
+  const scss = `@use '$scss/utils' as *;
+
+.something {
+  @include heading1;
+  display: flex;
+}
+`;
+  const tsx = `import classNames from 'classnames/bind';
+
+import styles from './Some.module.scss';
+const cx = classNames.bind(styles);
+
+export default function Some() {
+  return (
+    <div className={cx('something')}>
+      Hello world
+    </div>
+  );
+}
+`;
+
+  const client = makeClient({
+    readStyleFile: (path) => (path.endsWith("Some.module.scss") ? scss : null),
+    typeResolver: new FakeTypeResolver(),
+  });
+
+  await client.initialize();
+  client.initialized();
+
+  client.didOpen({
+    textDocument: {
+      uri: scssUri,
+      languageId: "scss",
+      version: 1,
+      text: scss,
+    },
+  });
+
+  const initial = await client.codeLens({ textDocument: { uri: scssUri } });
+  expect(initial).toBeNull();
+
+  client.didOpen({
+    textDocument: {
+      uri: tsxUri,
+      languageId: "typescriptreact",
+      version: 1,
+      text: tsx,
+    },
+  });
+  await client.waitForDiagnostics(tsxUri);
+  await client.waitForCodeLensRefresh();
+
+  const refreshed = await client.codeLens({ textDocument: { uri: scssUri } });
+  expect(refreshed).not.toBeNull();
+  expect(refreshed).toHaveLength(1);
+  expect(refreshed![0]!.command?.title).toBe("1 reference");
+});


### PR DESCRIPTION
## Summary
- refresh SCSS code lenses when semantic reference data changes
- cover the refresh path with a protocol test

## Verification
- pnpm test
- pnpm check