### PR TITLE
fix: include the extension package in the workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - "."
   - "client"
   - "examples"
   - "server"


### PR DESCRIPTION
## Summary
- include the repository root in the pnpm workspace
- unblock changesets versioning for the extension package

## Verification
- verified locally that the changesets versioning flow now recognizes the extension package