### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/codelens-refresh.md
+++ b/.changeset/codelens-refresh.md
@@ -1,5 +1,0 @@
----
-"css-module-explainer": patch
----
-
-Refresh SCSS reference count code lenses when semantic reference data changes so reference counts stay in sync after source analysis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.1
+
+### Patch Changes
+
+- [#2](https://github.com/yongsk0066/css-module-explainer/pull/2) [`d8ee9bd`](https://github.com/yongsk0066/css-module-explainer/commit/d8ee9bda19f0107a8f4aebe4139a6f0eba182452) Thanks [@yongsk0066](https://github.com/yongsk0066)! - Refresh SCSS reference count code lenses when semantic reference data changes so reference counts stay in sync after source analysis.
+
 All notable changes to this project will be documented in this
 file.
 
@@ -311,7 +317,7 @@ hot paths stay under 1 ms):
   index write exactly once per (uri, version) — never on
   provider hot paths.
 - **Workspace reverse index** — `(scssPath, className) →
-  CallSite[]` forward map plus a `uri → keys` back
+CallSite[]` forward map plus a `uri → keys` back
   pointer for O(|callSites|) `forget(uri)` on document
   close. Static call kinds only; template/variable are
   explicitly skipped for this release.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "css-module-explainer",
   "displayName": "CSS Module Explainer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Go to Definition, Hover, Autocomplete, Diagnostics, Quick Fixes, and Find References for classnames/bind cx() patterns with CSS Modules.",
   "categories": [

--- a/server/src/composition-root.ts
+++ b/server/src/composition-root.ts
@@ -37,7 +37,7 @@ import { registerHandlers } from "./handler-registration";
 import type { FileTask } from "./core/indexing/indexer-worker";
 
 const SERVER_NAME = "css-module-explainer";
-const SERVER_VERSION = "2.0.0";
+const SERVER_VERSION = "2.0.1";
 
 /**
  * Transport-agnostic shared options consumed by every


### PR DESCRIPTION
## Summary
- release the pending patch changeset
- bump the extension version to 2.0.1
- sync changelog and server version metadata