### PR TITLE
fix: support tsconfig path aliases for CSS Modules

### DIFF
--- a/.changeset/ts-path-aliases.md
+++ b/.changeset/ts-path-aliases.md
@@ -1,0 +1,9 @@
+---
+"css-module-explainer": minor
+---
+
+Add support for resolving CSS Module imports through `tsconfig.json` and `jsconfig.json`
+`compilerOptions.paths`, including wildcard aliases.
+
+This release also refreshes the examples sandbox with a dedicated tsconfig-path scenario
+so alias-import regressions are exercised outside the test harness.

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -9,6 +9,7 @@ import { FunctionScopedScenario } from "./scenarios/07-function-scoped/FunctionS
 import { CssOnlyScenario } from "./scenarios/08-css-only/CssOnlyScenario";
 import { LargeScenario } from "./scenarios/09-large/LargeScenario";
 import { ClsxScenario } from "./scenarios/10-clsx/ClsxScenario";
+import { TsPathScenario } from "./scenarios/11-ts-path/TsPathScenario";
 
 interface Scenario {
   readonly id: string;
@@ -78,6 +79,12 @@ const SCENARIOS: readonly Scenario[] = [
     title: "10 · clsx + styles.x",
     description: "clsx(styles.btn, cond && styles.active) and direct styles.x access.",
     render: () => <ClsxScenario />,
+  },
+  {
+    id: "11-ts-path",
+    title: "11 · tsconfig paths",
+    description: "Styles import resolved through compilerOptions.paths instead of a relative path.",
+    render: () => <TsPathScenario />,
   },
 ];
 

--- a/examples/src/scenarios/11-ts-path/TsPath.module.scss
+++ b/examples/src/scenarios/11-ts-path/TsPath.module.scss
@@ -1,0 +1,16 @@
+.panel {
+  padding: 16px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.title {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.body {
+  margin: 0;
+  color: #475569;
+}

--- a/examples/src/scenarios/11-ts-path/TsPathScenario.tsx
+++ b/examples/src/scenarios/11-ts-path/TsPathScenario.tsx
@@ -1,0 +1,19 @@
+import classNames from "classnames/bind";
+import styles from "$scenarios/11-ts-path/TsPath.module.scss";
+
+const cx = classNames.bind(styles);
+
+/**
+ * 11 · tsconfig paths — style import resolved through
+ * compilerOptions.paths instead of a relative specifier.
+ */
+export function TsPathScenario() {
+  return (
+    <section className={cx("panel")}>
+      <h3 className={cx("title")}>tsconfig path alias</h3>
+      <p className={cx("body")}>
+        The SCSS import uses <code>$scenarios/11-ts-path/TsPath.module.scss</code>.
+      </p>
+    </section>
+  );
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -11,7 +11,11 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "$scenarios/*": ["src/scenarios/*"]
+    }
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,7 +1,13 @@
+import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      $scenarios: path.resolve(__dirname, "src/scenarios"),
+    },
+  },
   server: { port: 5174 },
 });

--- a/server/src/core/cx/alias-resolver.ts
+++ b/server/src/core/cx/alias-resolver.ts
@@ -1,26 +1,111 @@
 import * as path from "node:path";
+import ts from "typescript";
 
 /**
- * Workspace-scoped path-alias resolver for CSS Module imports.
+ * Workspace-scoped path resolver for CSS Module imports.
  *
- * Reads the legacy-compatible `cssModules.pathAlias` record and
- * matches non-relative import specifiers against it using
- * longest-prefix semantics. `${workspaceFolder}` in target values
- * is substituted at construction time; relative targets are
- * resolved against `workspaceRoot`.
+ * Merges two alias sources:
+ *   - legacy-compatible `cssModules.pathAlias`
+ *   - `compilerOptions.paths` from the workspace tsconfig/jsconfig
  *
- * Alias matching uses longest-prefix order instead of relying on
- * object insertion order. A config like
- * `{ "@": "src", "@styles": "src/styles" }` therefore routes
- * `@styles/button` to `src/styles/button` regardless of key order.
+ * `${workspaceFolder}` in settings targets is substituted at
+ * construction time; relative settings targets are resolved
+ * against `workspaceRoot`. tsconfig/jsconfig targets are resolved
+ * against `compilerOptions.baseUrl` when present, otherwise the
+ * config file directory (`pathsBasePath` in the parsed TS config).
  *
- * No wildcard (`*`) support — tsconfig `compilerOptions.paths`
- * is the natural home for that and lives on a separate axis. No
- * filesystem check — the returned path may not exist; the
- * `fileExists` DI in `DocumentAnalysisCache` runs after and
- * produces a missing-module diagnostic for dangling alias
- * targets.
+ * Matching uses longest-pattern order instead of relying on
+ * insertion order. Explicit settings aliases win ties over
+ * tsconfig paths so user-authored extension config can override
+ * project config when needed.
+ *
+ * The resolver returns an absolute path even when the file does
+ * not exist. When multiple tsconfig targets exist for one pattern,
+ * an optional `fileExists` callback lets callers prefer the first
+ * candidate that exists on disk; otherwise the first target wins.
  */
+
+export interface TsconfigPathAliases {
+  readonly basePath: string;
+  readonly paths: Readonly<Record<string, readonly string[]>>;
+}
+
+type AliasEntry =
+  | {
+      readonly kind: "prefix";
+      readonly source: "settings" | "tsconfig";
+      readonly pattern: string;
+      readonly target: string;
+    }
+  | {
+      readonly kind: "wildcard";
+      readonly source: "tsconfig";
+      readonly pattern: string;
+      readonly prefix: string;
+      readonly suffix: string;
+      readonly targets: readonly string[];
+    };
+
+interface TsconfigPathAliasSystem extends Pick<
+  typeof ts.sys,
+  "fileExists" | "readFile" | "readDirectory" | "useCaseSensitiveFileNames"
+> {
+  readonly onUnRecoverableConfigFileDiagnostic?: (diagnostic: ts.Diagnostic) => void;
+}
+
+function compareAliasEntries(a: AliasEntry, b: AliasEntry): number {
+  if (a.pattern.length !== b.pattern.length) {
+    return b.pattern.length - a.pattern.length;
+  }
+  if (a.source !== b.source) {
+    return a.source === "settings" ? -1 : 1;
+  }
+  return a.pattern.localeCompare(b.pattern);
+}
+
+function findWorkspaceConfigPath(
+  workspaceRoot: string,
+  sys: Pick<typeof ts.sys, "fileExists">,
+): string | null {
+  return (
+    ts.findConfigFile(workspaceRoot, sys.fileExists, "tsconfig.json") ??
+    ts.findConfigFile(workspaceRoot, sys.fileExists, "jsconfig.json") ??
+    null
+  );
+}
+
+export function loadWorkspaceTsconfigPathAliases(
+  workspaceRoot: string,
+  system: TsconfigPathAliasSystem = {
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    readDirectory: ts.sys.readDirectory,
+    useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+    onUnRecoverableConfigFileDiagnostic: () => {},
+  },
+): TsconfigPathAliases | null {
+  try {
+    const configPath = findWorkspaceConfigPath(workspaceRoot, system);
+    if (!configPath) return null;
+
+    const parsed = ts.getParsedCommandLineOfConfigFile(configPath, undefined, {
+      ...ts.sys,
+      ...system,
+      onUnRecoverableConfigFileDiagnostic: system.onUnRecoverableConfigFileDiagnostic ?? (() => {}),
+    });
+    if (!parsed || !parsed.options.paths) return null;
+    const baseUrl = typeof parsed.options.baseUrl === "string" ? parsed.options.baseUrl : undefined;
+    const pathsBasePath =
+      typeof parsed.options.pathsBasePath === "string" ? parsed.options.pathsBasePath : undefined;
+
+    return {
+      basePath: baseUrl ?? pathsBasePath ?? path.dirname(configPath),
+      paths: parsed.options.paths,
+    };
+  } catch {
+    return null;
+  }
+}
 /**
  * Mutable holder for the workspace-scoped `AliasResolver`. The
  * composition root creates one at startup; `rebuildAliasResolver`
@@ -30,33 +115,52 @@ import * as path from "node:path";
  */
 export class AliasResolverHolder {
   private current: AliasResolver;
+  private settingsPathAlias: Readonly<Record<string, string>>;
 
   constructor(
     private readonly workspaceRoot: string,
     initial: Readonly<Record<string, string>>,
   ) {
-    this.current = new AliasResolver(workspaceRoot, initial);
+    this.settingsPathAlias = initial;
+    this.current = this.build();
   }
 
   get(): AliasResolver {
     return this.current;
   }
 
-  rebuild(pathAlias: Readonly<Record<string, string>>): void {
-    this.current = new AliasResolver(this.workspaceRoot, pathAlias);
+  rebuild(pathAlias: Readonly<Record<string, string>> = this.settingsPathAlias): void {
+    this.settingsPathAlias = pathAlias;
+    this.current = this.build();
+  }
+
+  private build(): AliasResolver {
+    return new AliasResolver(
+      this.workspaceRoot,
+      this.settingsPathAlias,
+      loadWorkspaceTsconfigPathAliases(this.workspaceRoot),
+    );
   }
 }
 
 export class AliasResolver {
-  private readonly sortedEntries: ReadonlyArray<readonly [string, string]>;
+  private readonly settingsEntries: readonly AliasEntry[];
+  private readonly tsconfigEntries: readonly AliasEntry[];
 
   constructor(
     private readonly workspaceRoot: string,
     pathAlias: Readonly<Record<string, string>>,
+    tsconfigPaths: TsconfigPathAliases | null = null,
   ) {
-    this.sortedEntries = Object.entries(pathAlias)
-      .map<[string, string]>(([k, v]) => [k, this.substituteWorkspace(v)])
-      .toSorted(([a], [b]) => b.length - a.length || a.localeCompare(b));
+    this.settingsEntries = Object.entries(pathAlias)
+      .map<AliasEntry>(([pattern, target]) => ({
+        kind: "prefix",
+        source: "settings",
+        pattern,
+        target: this.substituteWorkspace(target),
+      }))
+      .toSorted(compareAliasEntries);
+    this.tsconfigEntries = tsconfigPaths ? this.buildTsconfigEntries(tsconfigPaths) : [];
   }
 
   /**
@@ -65,15 +169,81 @@ export class AliasResolver {
    * back to relative resolution before accepting the specifier as
    * unresolved.
    */
-  resolve(specifier: string): string | null {
-    for (const [prefix, target] of this.sortedEntries) {
-      if (specifier === prefix) return target;
-      const normalised = prefix.endsWith("/") ? prefix : prefix + "/";
-      if (specifier.startsWith(normalised)) {
-        return path.resolve(target, specifier.slice(normalised.length));
+  resolve(specifier: string, fileExists?: (candidate: string) => boolean): string | null {
+    const resolvedFromSettings = this.resolveFromEntries(
+      this.settingsEntries,
+      specifier,
+      fileExists,
+    );
+    if (resolvedFromSettings) return resolvedFromSettings;
+    return this.resolveFromEntries(this.tsconfigEntries, specifier, fileExists);
+  }
+
+  private resolveFromEntries(
+    entries: readonly AliasEntry[],
+    specifier: string,
+    fileExists?: (candidate: string) => boolean,
+  ): string | null {
+    for (const entry of entries) {
+      if (entry.kind === "prefix") {
+        if (specifier === entry.pattern) return entry.target;
+        const normalised = entry.pattern.endsWith("/") ? entry.pattern : entry.pattern + "/";
+        if (specifier.startsWith(normalised)) {
+          return path.resolve(entry.target, specifier.slice(normalised.length));
+        }
+        continue;
       }
+
+      if (!specifier.startsWith(entry.prefix) || !specifier.endsWith(entry.suffix)) {
+        continue;
+      }
+      const matched = specifier.slice(entry.prefix.length, specifier.length - entry.suffix.length);
+      const candidates = entry.targets.map((targetPattern) =>
+        this.resolveTsconfigTarget(targetPattern, matched),
+      );
+      if (!fileExists) return candidates[0] ?? null;
+      const existing = candidates.find((candidate) => fileExists(candidate));
+      return existing ?? candidates[0] ?? null;
     }
     return null;
+  }
+
+  private buildTsconfigEntries(tsconfigPaths: TsconfigPathAliases): readonly AliasEntry[] {
+    const entries: AliasEntry[] = [];
+    for (const [pattern, targets] of Object.entries(tsconfigPaths.paths)) {
+      if (targets.length === 0) continue;
+      const wildcardIndex = pattern.indexOf("*");
+      if (wildcardIndex === -1) {
+        for (const target of targets) {
+          entries.push({
+            kind: "prefix",
+            source: "tsconfig",
+            pattern,
+            target: this.resolveTsconfigBaseTarget(tsconfigPaths.basePath, target),
+          });
+        }
+        continue;
+      }
+      entries.push({
+        kind: "wildcard",
+        source: "tsconfig",
+        pattern,
+        prefix: pattern.slice(0, wildcardIndex),
+        suffix: pattern.slice(wildcardIndex + 1),
+        targets: targets.map((target) =>
+          this.resolveTsconfigBaseTarget(tsconfigPaths.basePath, target),
+        ),
+      });
+    }
+    return entries;
+  }
+
+  private resolveTsconfigBaseTarget(basePath: string, target: string): string {
+    return path.isAbsolute(target) ? target : path.resolve(basePath, target);
+  }
+
+  private resolveTsconfigTarget(targetPattern: string, matched: string): string {
+    return targetPattern.includes("*") ? targetPattern.replaceAll("*", matched) : targetPattern;
   }
 
   private substituteWorkspace(target: string): string {

--- a/server/src/core/cx/binding-detector.ts
+++ b/server/src/core/cx/binding-detector.ts
@@ -71,7 +71,13 @@ export function scanCxImports(
   const stylesBindings = new Map<string, StyleImport>();
 
   for (const stmt of sourceFile.statements) {
-    const resolved = tryResolveImportStatement(stmt, sourceFile, filePath, aliasResolver);
+    const resolved = tryResolveImportStatement(
+      stmt,
+      sourceFile,
+      filePath,
+      fileExists,
+      aliasResolver,
+    );
     if (!resolved) continue;
     if (resolved.kind === "classnamesBind") {
       classNamesNames.add(resolved.importName);
@@ -131,6 +137,7 @@ function tryResolveImportStatement(
   stmt: ts.Statement,
   sourceFile: ts.SourceFile,
   filePath: string,
+  fileExists: (p: string) => boolean,
   aliasResolver: AliasResolver,
 ): ResolvedImport | null {
   if (!ts.isImportDeclaration(stmt)) return null;
@@ -157,7 +164,7 @@ function tryResolveImportStatement(
   if (specifier.startsWith(".")) {
     absolutePath = path.resolve(path.dirname(filePath), specifier);
   } else {
-    absolutePath = aliasResolver.resolve(specifier);
+    absolutePath = aliasResolver.resolve(specifier, fileExists);
     if (!absolutePath) return null;
   }
 

--- a/server/src/handler-registration.ts
+++ b/server/src/handler-registration.ts
@@ -221,6 +221,7 @@ function registerWatchedFilesHandler(state: HandlerState): void {
     if (!deps) return;
     let hasStyleChange = false;
     let hasSourceChange = false;
+    let hasProjectConfigChange = false;
     for (const change of params.changes) {
       const filePath = fileUrlToPath(change.uri);
       if (findLangForPath(filePath)) {
@@ -232,7 +233,13 @@ function registerWatchedFilesHandler(state: HandlerState): void {
         invalidateDependentTsxEntries(deps, filePath);
       } else {
         hasSourceChange = true;
+        if (isProjectConfigPath(filePath)) {
+          hasProjectConfigChange = true;
+        }
       }
+    }
+    if (hasProjectConfigChange) {
+      deps.rebuildAliasResolver(deps.settings.pathAlias);
     }
     if (hasSourceChange) {
       deps.typeResolver.invalidate(deps.workspaceRoot);
@@ -260,6 +267,13 @@ function registerWatchedFilesHandler(state: HandlerState): void {
       }
     }
   });
+}
+
+function isProjectConfigPath(filePath: string): boolean {
+  const base = filePath.split(/[\\/]/u).pop();
+  return (
+    base !== undefined && (/^tsconfig.*\.json$/u.test(base) || /^jsconfig.*\.json$/u.test(base))
+  );
 }
 
 /**

--- a/server/src/providers/provider-deps.ts
+++ b/server/src/providers/provider-deps.ts
@@ -81,12 +81,13 @@ export interface ProviderDeps {
    */
   settings: Settings;
   /**
-   * Rebuild the workspace-scoped path-alias resolver against a new
-   * `pathAlias` map. Callers (handler-registration's reloadSettings)
-   * MUST also call `analysisCache.clear()` after invoking this to
-   * discard stale entries that referenced the old resolver's output.
-   * The resolver itself lives inside `DocumentAnalysisCache` — no
-   * provider reads it directly.
+   * Rebuild the workspace-scoped import-path resolver against the
+   * latest extension `pathAlias` map plus the current tsconfig/jsconfig
+   * `compilerOptions.paths` state. Callers (handler-registration's
+   * reloadSettings and config-file watcher) MUST also clear cached
+   * analysis so stale import resolutions are discarded. The resolver
+   * itself lives inside `DocumentAnalysisCache` — no provider reads it
+   * directly.
    */
   rebuildAliasResolver(pathAlias: Readonly<Record<string, string>>): void;
   /**

--- a/test/protocol/_harness/in-process-server.ts
+++ b/test/protocol/_harness/in-process-server.ts
@@ -98,7 +98,9 @@ export function emptySupplier(): AsyncIterable<FileTask> {
 export interface InProcessServerOptions extends Omit<
   Extract<CreateServerOptions, { transport?: "auto" }>,
   "transport"
-> {}
+> {
+  readonly workspacePath?: string;
+}
 
 export interface LspTestClient {
   initialize(overrides?: Partial<InitializeParams>): Promise<InitializeResult>;
@@ -152,7 +154,8 @@ export interface LspTestClient {
  * Tests MUST call it in afterEach to avoid resource leaks.
  */
 export function createInProcessServer(options: InProcessServerOptions = {}): LspTestClient {
-  const workspacePath = path.resolve(process.cwd(), ".lsp-test-workspace");
+  const { workspacePath: customWorkspacePath, ...serverOptions } = options;
+  const workspacePath = customWorkspacePath ?? path.resolve(process.cwd(), ".lsp-test-workspace");
   const workspaceUri = pathToFileURL(workspacePath).toString();
   const serverToClient = new PassThrough();
   const clientToServer = new PassThrough();
@@ -189,7 +192,7 @@ export function createInProcessServer(options: InProcessServerOptions = {}): Lsp
     // diagnostics. Tests that exercise missing-module specifically
     // override via the `fileExists` option.
     fileExists: () => true,
-    ...options,
+    ...serverOptions,
     transport: "streams",
     reader: new StreamMessageReader(clientToServer),
     writer: new StreamMessageWriter(serverToClient),

--- a/test/protocol/tsconfig-path-alias.test.ts
+++ b/test/protocol/tsconfig-path-alias.test.ts
@@ -1,0 +1,78 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { expect, test } from "../_fixtures/protocol";
+
+test("tsconfig paths aliases resolve CSS Module imports across definition and codeLens", async ({
+  makeClient,
+}) => {
+  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), "cme-ts-path-"));
+  const tsxUri = "file:///fake/workspace/src/Some.tsx";
+  const scssUri = "file:///fake/workspace/src/components/Some.module.scss";
+  const tsx = `import classNames from 'classnames/bind';
+import styles from '$components/Some.module.scss';
+const cx = classNames.bind(styles);
+export default function Some() {
+  return <div className={cx('something')}>Hello world</div>;
+}
+`;
+  const scss = `.something {\n  display: flex;\n}\n`;
+
+  fs.mkdirSync(path.join(workspacePath, "src/components"), { recursive: true });
+  fs.writeFileSync(
+    path.join(workspacePath, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "$components/*": ["src/components/*"],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  try {
+    const client = makeClient({ workspacePath });
+    await client.initialize();
+    client.initialized();
+    client.didOpen({
+      textDocument: {
+        uri: scssUri,
+        languageId: "scss",
+        version: 1,
+        text: scss,
+      },
+    });
+    client.didOpen({
+      textDocument: {
+        uri: tsxUri,
+        languageId: "typescriptreact",
+        version: 1,
+        text: tsx,
+      },
+    });
+    await client.waitForDiagnostics(tsxUri);
+
+    const definition = await client.definition({
+      textDocument: { uri: tsxUri },
+      position: { line: 4, character: 29 },
+    });
+    expect(definition).not.toBeNull();
+    expect(definition).toHaveLength(1);
+    const first = definition![0]!;
+    expect("targetUri" in first ? first.targetUri : first.uri).toBe(scssUri);
+
+    const lenses = await client.codeLens({
+      textDocument: { uri: scssUri },
+    });
+    expect(lenses).not.toBeNull();
+    expect(lenses).toHaveLength(1);
+    expect(lenses![0]!.command?.title).toBe("1 reference");
+  } finally {
+    fs.rmSync(workspacePath, { recursive: true, force: true });
+  }
+});

--- a/test/unit/cx/alias-resolver.test.ts
+++ b/test/unit/cx/alias-resolver.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import * as path from "node:path";
-import { AliasResolver } from "../../../server/src/core/cx/alias-resolver";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import {
+  AliasResolver,
+  loadWorkspaceTsconfigPathAliases,
+} from "../../../server/src/core/cx/alias-resolver";
 
 const WORKSPACE = "/fake/ws";
 
@@ -74,5 +79,107 @@ describe("AliasResolver", () => {
     const r = new AliasResolver(WORKSPACE, { "@s": "src/styles" });
     // Equivalent to the commented plan behavior — workspace-relative default.
     expect(r.resolve("@s/button")).toBe(path.resolve(WORKSPACE, "src/styles/button"));
+  });
+
+  it("loads tsconfig wildcard paths and resolves them against baseUrl", () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "ts-path-alias-"));
+    fs.writeFileSync(
+      path.join(workspace, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            baseUrl: "./src",
+            paths: {
+              "$components/*": ["components/*"],
+              $styles: ["styles/Button.module.scss"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const tsconfigPaths = loadWorkspaceTsconfigPathAliases(workspace);
+    expect(tsconfigPaths).not.toBeNull();
+
+    const resolver = new AliasResolver(workspace, {}, tsconfigPaths);
+    expect(resolver.resolve("$components/Button.module.scss")).toBe(
+      path.resolve(workspace, "src/components/Button.module.scss"),
+    );
+    expect(resolver.resolve("$styles")).toBe(
+      path.resolve(workspace, "src/styles/Button.module.scss"),
+    );
+  });
+
+  it("falls back to jsconfig.json when tsconfig.json is absent", () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "js-path-alias-"));
+    fs.writeFileSync(
+      path.join(workspace, "jsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            paths: {
+              "$components/*": ["src/components/*"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const resolver = new AliasResolver(workspace, {}, loadWorkspaceTsconfigPathAliases(workspace));
+    expect(resolver.resolve("$components/Button.module.scss")).toBe(
+      path.resolve(workspace, "src/components/Button.module.scss"),
+    );
+  });
+
+  it("prefers explicit settings aliases over equal tsconfig patterns", () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "settings-overrides-"));
+    fs.writeFileSync(
+      path.join(workspace, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            baseUrl: ".",
+            paths: {
+              "@styles/*": ["from-tsconfig/*"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const resolver = new AliasResolver(
+      workspace,
+      { "@styles": "from-settings" },
+      loadWorkspaceTsconfigPathAliases(workspace),
+    );
+    expect(resolver.resolve("@styles/Button.module.scss")).toBe(
+      path.resolve(workspace, "from-settings/Button.module.scss"),
+    );
+  });
+
+  it("prefers the first existing tsconfig target when multiple candidates exist", () => {
+    const resolver = new AliasResolver(
+      WORKSPACE,
+      {},
+      {
+        basePath: path.resolve(WORKSPACE, "src"),
+        paths: {
+          "$components/*": ["missing/*", "real/*"],
+        },
+      },
+    );
+
+    expect(
+      resolver.resolve(
+        "$components/Button.module.scss",
+        (candidate) => candidate === path.resolve(WORKSPACE, "src/real/Button.module.scss"),
+      ),
+    ).toBe(path.resolve(WORKSPACE, "src/real/Button.module.scss"));
   });
 });

--- a/test/unit/cx/binding-detector.test.ts
+++ b/test/unit/cx/binding-detector.test.ts
@@ -505,6 +505,26 @@ describe("collectStyleImports", () => {
     }
   });
 
+  it("resolves tsconfig wildcard aliases via AliasResolver", () => {
+    const src = parse(`import s from '$components/button.module.scss';`);
+    const resolver = new AliasResolver(
+      "/fake",
+      {},
+      {
+        basePath: "/fake/src",
+        paths: {
+          "$components/*": ["components/*"],
+        },
+      },
+    );
+    const result = collectStyleImports(src, "/fake/src/Button.tsx", () => true, resolver);
+    expect(result.size).toBe(1);
+    expect(result.get("s")?.kind).toBe("resolved");
+    if (result.get("s")?.kind === "resolved") {
+      expect(result.get("s")!.absolutePath).toBe("/fake/src/components/button.module.scss");
+    }
+  });
+
   it("drops aliased imports with no matching alias (fallthrough)", () => {
     const src = parse(`import s from '@nope/button.module.scss';`);
     const resolver = new AliasResolver("/fake", { "@styles": "src/styles" });


### PR DESCRIPTION
## Summary
- resolve CSS Module imports through tsconfig/jsconfig `compilerOptions.paths`
- support wildcard path aliases and config-driven resolver rebuilds
- add protocol coverage and an examples scenario for alias imports

## Verification
- pnpm check
- pnpm test
- pnpm --dir examples build
