### PR TITLE
chore: release 3.1.1 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.1.0] — 2026-04-14
+## [3.1.1] — 2026-04-14
 
 ### Added
 
@@ -11,6 +11,7 @@
 
 ### Changed
 
+- **Stable promotion version** — the `3.1.0` version number was already consumed by the Marketplace pre-release channel, so the first stable cut of this feature line ships as `3.1.1`.
 - **Compatibility path alias guidance** — the native `cssModuleExplainer.pathAlias` key is now the preferred setting; falling back to `cssModules.pathAlias` logs a deprecation notice per workspace root.
 - **Examples sandbox expanded** — the manual QA matrix now includes dedicated `composes` coverage alongside the multi-root, shadowing, non-finite dynamic, and nested style fact scenarios.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "css-module-explainer",
   "displayName": "CSS Module Explainer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "description": "Go to Definition, Hover, Autocomplete, Diagnostics, Quick Fixes, and Find References for classnames/bind cx() patterns with CSS Modules.",
   "categories": [

--- a/server/src/composition-root.ts
+++ b/server/src/composition-root.ts
@@ -48,7 +48,7 @@ import {
 } from "./workspace/workspace-registry";
 
 const SERVER_NAME = "css-module-explainer";
-const SERVER_VERSION = "3.1.0";
+const SERVER_VERSION = "3.1.1";
 
 /**
  * Transport-agnostic shared options consumed by every


### PR DESCRIPTION
## Summary
- promote the 3.1 feature line to a stable Marketplace-compatible version
- replace the blocked `3.1.0` stable target with `3.1.1`
- keep the feature set identical to the validated 3.1 release candidate

## Verification
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm test:extension-host`
- `pnpm exec vsce package --no-dependencies`
