### PR TITLE
fix(ci): repair chronic nightly-soak checker-release-gate drift

### DIFF
--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -61,5 +61,15 @@ jobs:
   # NOTE: rust/omena-css/h1-readiness runs once nightly in omena-css-drift.yml
   # (08:00, green there). The duplicate 90-min soft run that lived here was removed
   # to stop running the same composite twice an hour apart (CI-hardening N7 dedup).
-  # The chronic nightly-soak red is the checker-release-gate / cargo-fuzz flake, a
-  # separate deferred investigation — NOT this h1-readiness duplicate.
+  #
+  # The chronic nightly-soak red (~2026-06-01..06-14) was the checker-release-gate
+  # job, NOT a cargo-fuzz flake. It was a 3-check chain of drift that ONLY this
+  # nightly release bundle runs (not PR/push CI), so it sat red for ~2 weeks:
+  #   1. check-rust-omena-syntax-parser-cst-equivalence.ts — asserted parser symbols
+  #      (`syntax()`, ParserCstEquivalenceSummaryV0, ...) in omena-parser/src/lib.rs,
+  #      but a module split moved them to parse.rs/summaries.rs. Fixed: scan whole crate.
+  #   2. check-rust-omena-syntax-extraction-decision.ts — same lib.rs-only drift. Fixed: same.
+  #   3. check-rust-omena-cli-soundiness-report.ts — stale FIXTURE: it expected an
+  #      unresolved `@use` to yield a suppressible `missingSassSymbol`, but per omena-cli
+  #      #33 an unreadable external edge now surfaces only `unresolvedExternalReference`
+  #      (intended, not a regression). Fixed: suppress a LOCAL undefined Sass var instead.

--- a/scripts/check-rust-omena-cli-soundiness-report.ts
+++ b/scripts/check-rust-omena-cli-soundiness-report.ts
@@ -32,13 +32,20 @@ const workspace = mkdtempSync(join(tmpdir(), "omena-cli-soundiness-report-"));
 
 try {
   const stylePath = join(workspace, "app.module.scss");
+  // The unresolved `@use` surfaces an `unresolvedExternalReference` boundary
+  // diagnostic; a genuinely-unresolvable module no longer also yields a
+  // speculative per-symbol `missingSassSymbol` (omena-cli #33: only on-disk
+  // readable edges get a bridge SIF, unreadable edges surface boundary state).
+  // The suppressible `missingSassSymbol` therefore comes from a LOCAL undefined
+  // Sass variable (`$brand`), so this fixture still exercises real suppression
+  // accounting (RED if suppression regresses) alongside the boundary diagnostic.
   writeFileSync(
     stylePath,
     [
       ".button { color: var(--missing); }",
       '@use "design-system/tokens" as tokens;',
       "/* omena-ignore-next-line missingSassSymbol [reason: 'awaiting upstream SIF'] */",
-      ".token { color: tokens.$brand; }",
+      ".token { color: $brand; }",
     ].join("\n"),
   );
 

--- a/scripts/check-rust-omena-syntax-extraction-decision.ts
+++ b/scripts/check-rust-omena-syntax-extraction-decision.ts
@@ -1,9 +1,18 @@
 import { strict as assert } from "node:assert";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
 const packageJson = readFileSync("package.json", "utf8");
 const syntaxSource = readFileSync("rust/crates/omena-syntax/src/lib.rs", "utf8");
-const parserSource = readFileSync("rust/crates/omena-parser/src/lib.rs", "utf8");
+
+// omena-parser's public surface is split across submodules (lib.rs facade +
+// parse.rs + summaries.rs + ...). Scan the whole crate src tree so these
+// assertions track symbols by content, not by file location — and so the
+// "no local SyntaxKind enum" guard also covers submodules, not just lib.rs.
+const parserSrcDir = "rust/crates/omena-parser/src";
+const parserSource = readdirSync(parserSrcDir, { recursive: true })
+  .filter((entry): entry is string => typeof entry === "string" && entry.endsWith(".rs"))
+  .map((entry) => readFileSync(`${parserSrcDir}/${entry}`, "utf8"))
+  .join("\n");
 const parserManifest = readFileSync("rust/crates/omena-parser/Cargo.toml", "utf8");
 const syntaxReadme = readFileSync("rust/crates/omena-syntax/README.md", "utf8");
 

--- a/scripts/check-rust-omena-syntax-parser-cst-equivalence.ts
+++ b/scripts/check-rust-omena-syntax-parser-cst-equivalence.ts
@@ -1,8 +1,17 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { strict as assert } from "node:assert";
 
 const syntaxSource = readFileSync("rust/crates/omena-syntax/src/lib.rs", "utf8");
-const parserSource = readFileSync("rust/crates/omena-parser/src/lib.rs", "utf8");
+
+// omena-parser's public surface is split across submodules (lib.rs re-export
+// facade + parse.rs + summaries.rs + ...). Scan the whole crate src tree so the
+// equivalence assertions track the symbols by content, not by file location —
+// otherwise an internal module split silently drifts this gate stale.
+const parserSrcDir = "rust/crates/omena-parser/src";
+const parserSource = readdirSync(parserSrcDir, { recursive: true })
+  .filter((entry): entry is string => typeof entry === "string" && entry.endsWith(".rs"))
+  .map((entry) => readFileSync(`${parserSrcDir}/${entry}`, "utf8"))
+  .join("\n");
 
 assert.match(
   syntaxSource,


### PR DESCRIPTION
Nightly Soak `checker-release-gate` had been red ~2026-06-01..06-14 — a 3-check drift chain that only the nightly release bundle runs (not PR/push CI), so it sat red ~2 weeks. NOT a cargo-fuzz flake.

1. `check-rust-omena-syntax-parser-cst-equivalence.ts` + 2. `check-rust-omena-syntax-extraction-decision.ts` — asserted parser symbols in `omena-parser/src/lib.rs` that a module split moved to `parse.rs`/`summaries.rs`. Now scan the whole crate src tree.
3. `check-rust-omena-cli-soundiness-report.ts` — stale fixture: unresolved `@use` now surfaces only `unresolvedExternalReference` (omena-cli #33, intended, not a regression). Suppresses a local undefined Sass var instead, keeping the suppression-accounting test's teeth.

Verified: `pnpm omena-check run rust/checker/release-gate-shadow` exits 0, all 85 bundle checks green. (PR CI does not exercise these checks — they live only in the nightly release bundle, which is the root cause; trust the local full-shadow exit 0.)