### PR TITLE
fix(bundler): oxfmt the restored design-decisions README

### DIFF
--- a/rust/crates/omena-bundler/README.md
+++ b/rust/crates/omena-bundler/README.md
@@ -54,7 +54,7 @@ crate). Each entry is a decision record, not a stability promise — this crate 
 still 0.x and its surface may change.
 
 1. **Q1 — bundler crate boundary: SUPERSEDED.** Originally resolved
-   *evolve-in-place; do NOT split a new `omena-bundler` crate* (a split would
+   _evolve-in-place; do NOT split a new `omena-bundler` crate_ (a split would
    disturb internal `omena-query` call sites and expand the crates.io +
    Trusted-Publishing release set — a recurring publish obligation). **This was
    later superseded:** the standalone `omena-bundler` crate WAS extracted at


### PR DESCRIPTION
Restores green master. PR #96's README addition wasn't oxfmt-formatted → oxfmt --check (verify lane) red at ca09f397. Whitespace-only reformat; `oxfmt --check .` clean across 897 files.