### PR TITLE
perf(cross-file): #93-cost re-wire (Slice 1: L1 resolution memo)

### DIFF
--- a/rust/crates/omena-query/src/style.rs
+++ b/rust/crates/omena-query/src/style.rs
@@ -1667,6 +1667,26 @@ fn apply_sass_module_graph_closure_step_configuration(
     metadata
 }
 
+// Test-only counter of ACTUAL configurable-name derivations (memo misses that run the parse +
+// disk-resolution work). With the L1 memo this is O(distinct modules); without it the same
+// derivation runs per enumerated closure path = O(paths) (super-polynomial). The end-to-end
+// growth gate (tests) asserts this stays ~linear, catching a regression of the L1 memo that the
+// output-only equivalence oracle cannot see. Compiled out of non-test builds (zero overhead).
+#[cfg(test)]
+thread_local! {
+    static CONFIGURABLE_NAMES_DERIVATIONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_configurable_names_derivation_count() {
+    CONFIGURABLE_NAMES_DERIVATIONS.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn configurable_names_derivation_count() -> u64 {
+    CONFIGURABLE_NAMES_DERIVATIONS.with(|count| count.get())
+}
+
 fn memoized_configurable_names(
     target_style_path: &str,
     context: SassModuleGraphClosureContext<'_>,
@@ -1681,6 +1701,8 @@ fn memoized_configurable_names(
         .source_by_path
         .get(target_style_path)
         .map(|target_source| {
+            #[cfg(test)]
+            CONFIGURABLE_NAMES_DERIVATIONS.with(|count| count.set(count.get() + 1));
             transform::derive_static_scss_module_configurable_variable_names_for_resolution(
                 target_style_path,
                 target_source,

--- a/rust/crates/omena-query/src/style.rs
+++ b/rust/crates/omena-query/src/style.rs
@@ -1,5 +1,6 @@
 use super::*;
 use omena_parser::{ParsedSassIncludeFact, ParsedSelectorFact, ParsedVariableFact};
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
 mod cascade_position;
@@ -1325,6 +1326,8 @@ fn summarize_sass_module_cross_file_resolution(
     let unresolved_module_edge_count = edges
         .len()
         .saturating_sub(resolved_module_edge_count + external_module_edge_count);
+    let configurable_names_memo: RefCell<BTreeMap<String, BTreeSet<String>>> =
+        RefCell::new(BTreeMap::new());
     let (graph_closure_edges, cycles) = summarize_sass_module_graph_closure(
         &edges,
         SassModuleGraphClosureContext {
@@ -1333,6 +1336,7 @@ fn summarize_sass_module_cross_file_resolution(
             package_manifests,
             bundler_path_mappings,
             tsconfig_path_mappings,
+            configurable_names_memo: &configurable_names_memo,
         },
     );
     let visibility_filter_count = edges
@@ -1519,6 +1523,13 @@ struct SassModuleGraphClosureContext<'a> {
     package_manifests: &'a [OmenaQueryStylePackageManifestV0],
     bundler_path_mappings: &'a [OmenaResolverBundlerPathAliasMappingV0],
     tsconfig_path_mappings: &'a [OmenaResolverTsconfigPathMappingV0],
+    // Run-scoped memo of per-target configurable variable names. The derivation is a pure
+    // function of `target_style_path` within one closure computation (every other input is a
+    // fixed `context` field), but the same target recurs across super-polynomially many
+    // enumerated closure paths. Caching it per target collapses that to one derivation per
+    // module without changing any emitted value. Scoped to a single summary run (created at the
+    // call site, dropped when it returns) so a later revision re-reads disk — no stale resolution.
+    configurable_names_memo: &'a RefCell<BTreeMap<String, BTreeSet<String>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -1613,21 +1624,7 @@ fn derive_sass_module_graph_closure_step_variable_overrides(
     };
     match metadata.edge_kind {
         "sassForward" => {
-            let configurable_names = context
-                .source_by_path
-                .get(target_style_path)
-                .map(|target_source| {
-                    transform::derive_static_scss_module_configurable_variable_names_for_resolution(
-                        target_style_path,
-                        target_source,
-                        context.available_style_paths,
-                        context.source_by_path,
-                        context.package_manifests,
-                        context.bundler_path_mappings,
-                        context.tsconfig_path_mappings,
-                    )
-                })
-                .unwrap_or_default();
+            let configurable_names = memoized_configurable_names(target_style_path, context);
             transform::derive_static_scss_forward_effective_configuration_for_resolution_at_ordinal(
                 style_source,
                 metadata.rule_ordinal,
@@ -1652,21 +1649,7 @@ fn apply_sass_module_graph_closure_step_configuration(
     variable_overrides: BTreeMap<String, String>,
     context: SassModuleGraphClosureContext<'_>,
 ) -> SassModuleGraphClosureStepMetadata {
-    let configurable_names = context
-        .source_by_path
-        .get(target_style_path)
-        .map(|target_source| {
-            transform::derive_static_scss_module_configurable_variable_names_for_resolution(
-                target_style_path,
-                target_source,
-                context.available_style_paths,
-                context.source_by_path,
-                context.package_manifests,
-                context.bundler_path_mappings,
-                context.tsconfig_path_mappings,
-            )
-        })
-        .unwrap_or_default();
+    let configurable_names = memoized_configurable_names(target_style_path, context);
     metadata.invalid_configuration_variable_names = variable_overrides
         .keys()
         .filter(|name| !configurable_names.contains(*name))
@@ -1682,6 +1665,38 @@ fn apply_sass_module_graph_closure_step_configuration(
         ),
     );
     metadata
+}
+
+fn memoized_configurable_names(
+    target_style_path: &str,
+    context: SassModuleGraphClosureContext<'_>,
+) -> BTreeSet<String> {
+    {
+        let cache = context.configurable_names_memo.borrow();
+        if let Some(cached) = cache.get(target_style_path) {
+            return cached.clone();
+        }
+    }
+    let computed = context
+        .source_by_path
+        .get(target_style_path)
+        .map(|target_source| {
+            transform::derive_static_scss_module_configurable_variable_names_for_resolution(
+                target_style_path,
+                target_source,
+                context.available_style_paths,
+                context.source_by_path,
+                context.package_manifests,
+                context.bundler_path_mappings,
+                context.tsconfig_path_mappings,
+            )
+        })
+        .unwrap_or_default();
+    context
+        .configurable_names_memo
+        .borrow_mut()
+        .insert(target_style_path.to_string(), computed.clone());
+    computed
 }
 
 fn summarize_css_modules_cross_file_resolution(

--- a/rust/crates/omena-query/src/tests/style_semantic_graph.rs
+++ b/rust/crates/omena-query/src/tests/style_semantic_graph.rs
@@ -1045,3 +1045,91 @@ fn style_semantic_graph_batch_resolves_package_manifest_style_exports() {
     );
     assert_eq!(declaration_candidate.import_graph_distance, Some(1));
 }
+
+// Builds a cyclic @use/@forward SCSS corpus (mirrors the #93 reproduction): App @use barrel;
+// barrel @forwards N children; each child @forwards a grandchild AND @uses the next child in a
+// ring (i -> i%N+1) so the N children form one strongly-connected component. This is the shape
+// that makes naive all-paths enumeration super-polynomial.
+fn cyclic_sass_module_corpus(n: usize) -> Vec<(String, String)> {
+    let mut files = Vec::new();
+    let mut barrel = String::new();
+    for i in 1..=n {
+        barrel.push_str(&format!("@forward \"./child_{i}\";\n"));
+    }
+    files.push(("/cyc/_barrel.scss".to_string(), barrel));
+    for i in 1..=n {
+        let next = i % n + 1;
+        files.push((
+            format!("/cyc/_child_{i}.scss"),
+            format!(
+                "@forward \"./gc_{i}\";\n@use \"./child_{next}\" as n_{i};\n$ds_gray_{i}: {};\n.tok_{i} {{ padding: $ds_gray_{i}; }}\n",
+                100 + i
+            ),
+        ));
+        files.push((
+            format!("/cyc/_gc_{i}.scss"),
+            format!("$gc_tone_{i}: {i};\n.gc_{i} {{ margin: $gc_tone_{i}; }}\n"),
+        ));
+    }
+    files.push((
+        "/cyc/App.module.scss".to_string(),
+        "@use \"./barrel\" as ds;\n.app { color: red; }".to_string(),
+    ));
+    files
+}
+
+fn fit_growth_exponent(samples: &[(f64, f64)]) -> f64 {
+    let n = samples.len() as f64;
+    let xs: Vec<f64> = samples.iter().map(|(x, _)| x.ln()).collect();
+    let ys: Vec<f64> = samples.iter().map(|(_, y)| y.max(1.0).ln()).collect();
+    let sx: f64 = xs.iter().sum();
+    let sy: f64 = ys.iter().sum();
+    let sxx: f64 = xs.iter().map(|x| x * x).sum();
+    let sxy: f64 = xs.iter().zip(ys.iter()).map(|(x, y)| x * y).sum();
+    (n * sxy - sx * sy) / (n * sxx - sx * sx)
+}
+
+// End-to-end anti-recurrence gate (replaces the prior leg-isolated, tautological growth check):
+// drive the FULL cross-file resolution over a cyclic corpus at >=3 sizes and assert that the
+// number of configurable-name DERIVATIONS (the parse + disk-resolution work that the L1 run-scoped
+// memo collapses to O(distinct modules)) grows ~linearly. Removing the L1 memo makes the same
+// derivation run per enumerated closure path = O(paths) (super-polynomial, ~2.6 measured) and turns
+// this RED — a perf regression the output-only equivalence oracle would NOT catch. The path
+// enumeration itself (graph_closure_edge_count) stays super-polynomial by design and is reported
+// advisorily, not asserted (eliminating it is the deferred config-state-worklist work).
+#[test]
+fn cross_file_configurable_name_derivations_grow_near_linearly_end_to_end() {
+    let input = sample_input();
+    let mut derivation_samples: Vec<(f64, f64)> = Vec::new();
+    let mut edge_samples: Vec<(f64, f64)> = Vec::new();
+    for n in [4usize, 8, 16] {
+        let corpus = cyclic_sass_module_corpus(n);
+        let styles: Vec<(&str, &str)> = corpus
+            .iter()
+            .map(|(path, source)| (path.as_str(), source.as_str()))
+            .collect();
+        crate::style::reset_configurable_names_derivation_count();
+        let batch = summarize_omena_query_style_semantic_graph_batch_from_sources(styles, &input);
+        let derivations = crate::style::configurable_names_derivation_count();
+        let edges = batch.sass_module_resolution.graph_closure_edge_count;
+        // Sanity: the corpus must actually exercise the forward-config derivation path.
+        assert!(
+            derivations > 0,
+            "corpus N={n} did not exercise configurable-name derivation"
+        );
+        derivation_samples.push((n as f64, derivations as f64));
+        edge_samples.push((n as f64, edges as f64));
+    }
+    let derivation_exponent = fit_growth_exponent(&derivation_samples);
+    let edge_exponent = fit_growth_exponent(&edge_samples);
+    eprintln!(
+        "configurable-name derivations (L1-memo, asserted ~linear): {derivation_samples:?} exponent={derivation_exponent:.3}"
+    );
+    eprintln!(
+        "graph_closure_edge_count (path enumeration, advisory): {edge_samples:?} exponent={edge_exponent:.3}"
+    );
+    assert!(
+        derivation_exponent <= 1.3,
+        "cross-file configurable-name derivations must grow ~linearly in module count (L1 memo intact); exponent={derivation_exponent:.3}, samples={derivation_samples:?}"
+    );
+}


### PR DESCRIPTION
Fundamental cost re-wire of the cross-file Sass closure (follow-up to #93, which fixed the crash but left the cost super-poly: b≈2.5, only a ~5× constant gain).

Root cause (profiled): resolution + reachability + path-sensitive config are conflated into one eager, un-memoized, all-paths, whole-corpus computation rebuilt per cold open. The dominant cost is per-path **re-resolution** (open/stat/readlink storm).

This PR stacks the re-wire slices, all **byte-identical / pure-performance**, each oracle-gated:

- [x] **Slice 1 — L1 run-scoped resolution memo** (`22460190`). Memoize per-target configurable-name derivation (a pure fn of `target_style_path` within a run) → collapses super-poly repeated re-resolution to O(modules). Byte-identical (oracle + 317 query tests + cli/lsp green, no golden churn; reaches counts unchanged). Profile: exponent **2.56 → 1.51**, N=8 13.5×, N=16 DNF→8.9s. Run-scoped (no stale resolution across symlink retarget).
- [ ] Slice 2 — L3 config-state worklist (replace RawAllPaths all-paths enumeration for the @forward-with-config diagnostic; keep cycle/SCC full-graph; oracle-pin config-order soundness).
- [ ] Slice 3 — demand-slice + streaming-leg salsa-lift.
- [ ] Slice 4 — end-to-end exponent/slope gate (replace the tautological leg-isolated gate).

Draft while slices stack. Each slice: implement → verify (tests + oracle + profile) → review → review-of-review → commit.