### PR TITLE
test(ci): probe product test failures

### DIFF
--- a/rust/crates/omena-benchmarks/src/lib.rs
+++ b/rust/crates/omena-benchmarks/src/lib.rs
@@ -1627,7 +1627,7 @@ mod tests {
             snapshot.dart_sass_advisory_policy,
             "advisory-only-plain-sass-subset; css-modules-moat-never-external-gated"
         );
-        assert!(!snapshot.speed_claim_ready);
+        assert!(snapshot.speed_claim_ready);
         assert!(
             snapshot
                 .samples

--- a/rust/crates/omena-cascade-proof/src/lib.rs
+++ b/rust/crates/omena-cascade-proof/src/lib.rs
@@ -919,7 +919,7 @@ mod tests {
         let report = run_smt_bisimulation_fuzz_seed_corpus_v0(128);
         assert_eq!(report.schema_version, "0");
         assert_eq!(report.fixture_suite, "m3-cascade-proof-fixtures");
-        assert_eq!(report.checked_obligation_count, 128 * 4);
+        assert_eq!(report.checked_obligation_count, 0);
         assert_eq!(report.l1_l3_mismatch_count, 0);
         assert!(report.passed);
     }

--- a/rust/crates/omena-query-transform-runner/src/lib.rs
+++ b/rust/crates/omena-query-transform-runner/src/lib.rs
@@ -140,7 +140,7 @@ mod tests {
     fn transform_runner_boundary_collapses_transform_family_for_query() {
         let summary = summarize_omena_query_transform_runner_boundary_v0();
 
-        assert_eq!(summary.collapsed_transform_crate_count, 6);
+        assert_eq!(summary.collapsed_transform_crate_count, 5);
         assert_eq!(
             summary.collapsed_transform_crates,
             OMENA_QUERY_TRANSFORM_RUNNER_COLLAPSED_CRATES_V0

--- a/rust/crates/omena-transform-egg/src/lib.rs
+++ b/rust/crates/omena-transform-egg/src/lib.rs
@@ -978,7 +978,7 @@ mod tests {
                 "stale-prefix-removal"
             ]
         );
-        assert_eq!(boundary.proof_obligations.len(), 6);
+        assert_eq!(boundary.proof_obligations.len(), 7);
     }
 
     #[test]


### PR DESCRIPTION
Temporary CI verification PR for bundler product-test red evidence. This PR is intentionally failing and will not be merged.