### PR TITLE
fix(lsp): coalesce admit-wave external SIF refreshes to one round at index quiesce

### DIFF
--- a/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
+++ b/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
@@ -169,6 +169,11 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
                     continue;
                 }
                 let elapsed_millis = started_at.elapsed().as_millis() as u64;
+                omena_lsp_server::loop_trace!(
+                    "diag-wave-done key={} elapsed_ms={}",
+                    work.dispatch.coalesce_key,
+                    elapsed_millis
+                );
                 let remaining_delay =
                     OPTIMIZING_DIAGNOSTICS_DELAY_MS.saturating_sub(elapsed_millis);
                 if remaining_delay > 0 {
@@ -576,6 +581,11 @@ fn dispatch_deferred_diagnostics(
     dispatch: LspDeferredDiagnosticsDispatchV0,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let revision = lock_coalescer(coalescer).schedule(dispatch.coalesce_key.as_str());
+    omena_lsp_server::loop_trace!(
+        "diag-dispatch key={} rev={}",
+        dispatch.coalesce_key,
+        revision
+    );
     sender
         .send(DeferredDiagnosticsWorkV0 { dispatch, revision })
         .map_err(|_| "diagnostics worker exited before shutdown".into())

--- a/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
@@ -47,6 +47,10 @@ pub fn external_sif_refresh_follow_up_diagnostics_effects(
     }
     #[cfg(test)]
     warmup_wave_count_probe::record();
+    crate::loop_trace!(
+        "sif-follow-up fired for {} style docs (deferred)",
+        uris.len()
+    );
     let effects = diagnostics_scheduler::run_diagnostics_schedule_effects(
         state,
         diagnostics_scheduler::DiagnosticsScheduleEvent::WatchedFiles { uris },

--- a/rust/crates/omena-lsp-server/src/document_refresh.rs
+++ b/rust/crates/omena-lsp-server/src/document_refresh.rs
@@ -278,6 +278,13 @@ pub(crate) fn refresh_style_external_inputs_for_document_event(
         admit_foreign_style_dependencies_for_style_uri(state, uri);
     }
 
+    crate::loop_trace!(
+        "doc-ext-refresh uri={} bridge_eq={} foreign_prev={} foreign_next={}",
+        uri.rsplit('/').next().unwrap_or(uri),
+        previous.bridge_sources == next.bridge_sources,
+        previous.foreign_dependency_uris.len(),
+        next.foreign_dependency_uris.len()
+    );
     if previous.bridge_sources != next.bridge_sources {
         refresh_external_sifs_for_bridge_source_delta(
             state,

--- a/rust/crates/omena-lsp-server/src/external_sif_loader.rs
+++ b/rust/crates/omena-lsp-server/src/external_sif_loader.rs
@@ -41,6 +41,10 @@ pub struct LspExternalSifRefreshResultV0 {
 
 pub(crate) fn refresh_external_sifs_for_state(state: &mut LspShellState) {
     if state.external_sif_refresh_deferred {
+        crate::loop_trace!(
+            "sif-dirty reason=state-refresh rev->{}",
+            state.external_sif_refresh_revision + 1
+        );
         mark_external_sif_refresh_dirty(state);
         return;
     }
@@ -81,6 +85,25 @@ pub(crate) fn refresh_external_sifs_for_bridge_source_delta(
     next_sources: &[String],
 ) {
     if state.external_sif_refresh_deferred {
+        // Mirror the immediate arm's early return: an unchanged bridge-source
+        // set has nothing to refresh, so it must not mark the deferred job
+        // dirty (previously every no-op admit wave scheduled a full external
+        // SIF re-resolution and raced the in-flight one's revision).
+        let previous_set = previous_sources.iter().collect::<BTreeSet<_>>();
+        let next_set = next_sources.iter().collect::<BTreeSet<_>>();
+        if previous_set == next_set {
+            crate::loop_trace!(
+                "sif-dirty SKIPPED reason=bridge-delta-equal len={}",
+                next_set.len()
+            );
+            return;
+        }
+        crate::loop_trace!(
+            "sif-dirty reason=bridge-delta prev={} next={} rev->{}",
+            previous_sources.len(),
+            next_sources.len(),
+            state.external_sif_refresh_revision + 1
+        );
         mark_external_sif_refresh_dirty(state);
         return;
     }
@@ -186,6 +209,15 @@ pub fn prepare_deferred_external_sif_refresh_job(
         return None;
     }
     state.external_sif_refresh_dirty = false;
+    crate::loop_trace!(
+        "sif-job-prepared rev={} docs={}",
+        state.external_sif_refresh_revision,
+        state
+            .documents
+            .values()
+            .filter(|d| is_style_document_uri(d.uri.as_str()))
+            .count()
+    );
     Some(LspExternalSifRefreshJobV0 {
         revision: state.external_sif_refresh_revision,
         lockfiles: workspace_lockfiles(state),
@@ -248,6 +280,11 @@ pub fn apply_deferred_external_sif_refresh_result(
     result: LspExternalSifRefreshResultV0,
 ) -> bool {
     if result.revision != state.external_sif_refresh_revision {
+        crate::loop_trace!(
+            "sif-apply DISCARDED result_rev={} state_rev={}",
+            result.revision,
+            state.external_sif_refresh_revision
+        );
         return false;
     }
     state.external_sif_lock_read_count = state
@@ -257,6 +294,13 @@ pub fn apply_deferred_external_sif_refresh_result(
         .external_sif_bridge_generation_count
         .saturating_add(result.bridge_generation_count);
     let changed = state.resolution.external_sifs != result.external_sifs;
+    crate::loop_trace!(
+        "sif-apply rev={} changed={} sifs {}->{}",
+        result.revision,
+        changed,
+        state.resolution.external_sifs.len(),
+        result.external_sifs.len()
+    );
     if changed {
         state.resolution.external_sifs = result.external_sifs;
         invalidate_external_sif_dependents(state);

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -230,6 +230,23 @@ pub(crate) use workspace_resolution::{
 };
 
 pub const NODE_TEXT_DOCUMENT_SYNC_KIND: u8 = 2;
+
+pub fn omena_loop_trace_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("OMENA_LOOP_TRACE").is_some())
+}
+
+#[macro_export]
+macro_rules! loop_trace {
+    ($($arg:tt)*) => {
+        if $crate::omena_loop_trace_enabled() {
+            eprintln!("[LOOPTRACE {:>10.3}] {}",
+                std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs_f64()%100000.0).unwrap_or(0.0),
+                format!($($arg)*));
+        }
+    };
+}
+
 pub const DEBUG_STATE_REQUEST: &str = "omena/rustLspState";
 pub const RUNTIME_LOOP_PROBE_REQUEST: &str = "omena/runtimeLoopProbe";
 pub const STYLE_HOVER_CANDIDATES_REQUEST: &str = "omena/rustStyleHoverCandidates";

--- a/rust/crates/omena-lsp-server/src/state.rs
+++ b/rust/crates/omena-lsp-server/src/state.rs
@@ -312,6 +312,10 @@ pub struct LspShellState {
     pub(crate) external_sif_bridge_generation_count: usize,
     pub(crate) external_sif_refresh_deferred: bool,
     pub(crate) external_sif_refresh_dirty: bool,
+    /// Set when a background index wave admits style documents; consumed by
+    /// the index-quiesce check (`pending == 0`) that schedules ONE external
+    /// SIF refresh for the whole admission burst instead of one per wave.
+    pub(crate) external_sif_refresh_owed_for_admitted_styles: bool,
     pub(crate) external_sif_refresh_revision: u64,
     pub(crate) workspace_index_revision: u64,
     pub(crate) configuration_change_count: usize,

--- a/rust/crates/omena-lsp-server/src/workspace_index.rs
+++ b/rust/crates/omena-lsp-server/src/workspace_index.rs
@@ -166,12 +166,40 @@ pub fn apply_background_workspace_index_result(
     let mut bridge_source_uris = indexed_style_uris;
     bridge_source_uris.extend(admitted_foreign_uris);
     let next_bridge_sources = crate::bridge_sources_for_style_uris(state, &bridge_source_uris);
+    if !bridge_source_uris.is_empty() {
+        // Newly admitted style documents owe an external-SIF refresh even
+        // when the bridge-source *summary* is unchanged: the deferred refresh
+        // job is what discovers bridge SIFs from the newly admitted document
+        // set (and its follow-up republishes diagnostics against the settled
+        // resolution state). The debt is settled ONCE at index quiesce below
+        // — scheduling per admit wave races the in-flight job's revision and
+        // multiplies full-workspace diagnostics rounds.
+        state.external_sif_refresh_owed_for_admitted_styles = true;
+    }
     crate::refresh_external_sifs_for_bridge_source_delta(
         state,
         previous_bridge_sources.as_slice(),
         next_bridge_sources.as_slice(),
     );
+    crate::loop_trace!(
+        "index-apply admitted_style={} pending={} exhausted={}",
+        bridge_source_uris.len(),
+        result.pending_file_count,
+        result.exhausted
+    );
     state.workspace_index_pending_file_count = result.pending_file_count;
+    // Deferred arm only: the immediate arm keeps its delta-scoped refresh
+    // invariant (an index apply never reruns the whole-state lockfile
+    // refresh); the deferred arm settles the admission debt as ONE dirty
+    // mark at quiesce, which the loop turns into a single refresh job.
+    if state.external_sif_refresh_deferred
+        && result.pending_file_count == 0
+        && state.external_sif_refresh_owed_for_admitted_styles
+    {
+        state.external_sif_refresh_owed_for_admitted_styles = false;
+        crate::loop_trace!("index-quiesce schedules sif refresh");
+        crate::refresh_external_sifs_for_state(state);
+    }
     if result.exhausted {
         state.workspace_style_index_exhausted_count += 1;
     }


### PR DESCRIPTION
## Problem

Cold-opening a large workspace (137 workspace-local style documents) kept the LSP server at ~100% of one core for **35+ minutes without settling**, while the editor itself stayed functional. Traced with env-gated instrumentation, the cause is an amplification chain rather than a hot function:

```
index admit waves (~20 per cold open)
  → deferred bridge-delta arm dirty-marks UNCONDITIONALLY per wave      [igniter]
  → 19 full-workspace SIF jobs, 10 discarded by revision races          [waste]
  → TWO changed=true applies (SIFs 0→10, then 10→19)
  → each apply's follow-up republishes ALL 137 style documents          [amplifier]
  → post-invalidation cold per-target cross-file query ≈ 7.7 s/wave
  → 137 × 7.7 s × 2 rounds ≈ 35 min
```

Full experiment log — baseline traces, hypothesis discrimination (uniform 7.7 s on byte-identical same-tick snapshots refutes the resync theory; warm edit republish is 611 ms on the same corpus), rejected attempts, and the reproduction protocol: **omenien/rfcs#110**.

## Fix (deferred arm only)

1. `refresh_external_sifs_for_bridge_source_delta`: early-return when the bridge-source set is unchanged, mirroring the immediate arm (the deferred arm previously dirty-marked on every no-op admit wave).
2. Admit waves that admitted style documents set an **owed flag** instead of scheduling a refresh; the flag is consumed **once** when an index apply reports `pending_file_count == 0`. The single job runs against the settled document set, so the SIF set transitions `0 → final` in one `changed=true` apply and the workspace-wide follow-up fires exactly once.

The quiesce refresh is gated to `external_sif_refresh_deferred`: the immediate arm keeps its delta-scoped invariant ("an index apply never reruns the whole-state lockfile refresh" — the existing test caught the first, unguarded version of this change).

Rejected alternative (documented in rfcs#110 §5.1): routing the follow-up through the batched parallel wave cuts total CPU ~4× but runs synchronously on the main loop → 4+ minutes of full unresponsiveness. The per-file deferred arm keeps the round off-loop and coalescer-supersedable.

## Measurements (same workspace, before → after)

| | before | after |
|---|---|---|
| dirty marks per cold open | 23 | 2 (startup handshake) |
| SIF jobs / discarded applies | 19 / 10 | 3 / 1 |
| `changed=true` applies | 2 | **1** (single `0→19` transition) |
| follow-up rounds | 2 (5 + 137 docs) | **1** (137 docs) |
| settle | 35+ min, non-settling | **CPU 0.2% at t=18.5 min** |
| hover during the background round | — | 18.6–36 ms (37/37 samples) |

Correctness: the transient partial-SIF `unresolvedExternalReference` on the open document clears after settle, and the converged diagnostic set is byte-identical across repeated waves (idempotent).

The remaining single background round (137 × 7.7 s ≈ 17.6 CPU-minutes, one worker core) is the C1 unwired-incremental floor quantified in rfcs#110 §9 — follow-up designs there (off-loop batched wave job with disk-cache write-behind; C1 wiring projects the round to ≈ 1.4 min).

## Commits

- `chore(lsp): add env-gated loop trace instrumentation` — `OMENA_LOOP_TRACE`-gated `loop_trace!` macro + the trace points that localized the loop (zero cost when unset; keeps the rfcs#110 signatures reproducible).
- `fix(lsp): coalesce admit-wave external SIF refreshes to one round at index quiesce` — the two-part fix above.

## Tests

- `cargo test -p omena-lsp-server --features test-support --lib -- --test-threads=1`: **178/178**.
- Parallel runs fail 2 `resolver_identity_index` tests **on clean master as well** (pre-existing global-counter pollution flake, reproduced 2/2 on master; isolated and single-threaded runs pass) — noted in rfcs#110 §9.4, not addressed here.
- 18.9-minute headless verification probe against the real workspace: one round, flat hover latency, early-exit on settle.
