### PR TITLE
feat(tide): settle-gated scheduling topology over a footprinted epoch ledger (rfcs#111 M0-M4)

### DIFF
--- a/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
+++ b/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
@@ -27,7 +27,7 @@ use omena_lsp_server::{
 #[cfg(feature = "parallel-style-diagnostics")]
 use omena_lsp_server::{
     TideWorkspaceRepublishItemV0, TideWorkspaceRepublishJobV0, TideWorkspaceRepublishResultV0,
-    apply_tide_workspace_republish_item, collect_tide_workspace_republish,
+    apply_tide_workspace_republish_item, collect_tide_workspace_republish_streaming,
     complete_tide_workspace_republish, prepare_tide_workspace_republish_job,
 };
 
@@ -105,10 +105,9 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
     #[cfg(feature = "parallel-style-diagnostics")]
     let tide_republish_worker: JoinHandle<Result<(), String>> = thread::spawn(move || {
         while let Ok(job) = tide_republish_job_receiver.recv() {
-            let result = collect_tide_workspace_republish(job);
-            tide_republish_result_sender
-                .send(result)
-                .map_err(|_| "tide republish result receiver dropped".to_string())?;
+            collect_tide_workspace_republish_streaming(job, &mut |result| {
+                tide_republish_result_sender.send(result).is_ok()
+            });
         }
         Ok(())
     });
@@ -430,6 +429,7 @@ struct PendingTideRepublishApplyV0 {
     generation: u64,
     items: std::collections::VecDeque<TideWorkspaceRepublishItemV0>,
     uncovered_uris: Vec<String>,
+    final_chunk_seen: bool,
 }
 
 #[cfg(feature = "parallel-style-diagnostics")]
@@ -469,36 +469,27 @@ fn drain_and_pump_tide_republish<W: Write + Send + 'static>(
     >,
 ) -> Result<(), Box<dyn std::error::Error>> {
     while let Ok(result) = receiver.try_recv() {
-        *in_flight = in_flight.saturating_sub(1);
-        let current = state.tide_republish_lane_generation() == result.generation;
-        if current && !result.items.is_empty() {
-            *pending = Some(PendingTideRepublishApplyV0 {
-                generation: result.generation,
-                items: result.items.into(),
-                uncovered_uris: result.uncovered_uris,
-            });
-        } else {
-            // Disowned mid-wave, or nothing covered: complete now. A CURRENT
-            // empty wave still owes its uncovered targets to the fallback arm.
-            let uncovered_uris = if current {
-                result.uncovered_uris
-            } else {
-                Vec::new()
-            };
-            let effects =
-                complete_tide_workspace_republish(state, result.generation, uncovered_uris);
-            for output in effects.outputs {
-                write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
-            }
-            for dispatch in effects.deferred_diagnostics {
-                #[cfg(feature = "salsa-style-diagnostics")]
-                dispatch_deferred_diagnostics(diagnostics_sender, coalescer, dispatch)?;
-                #[cfg(not(feature = "salsa-style-diagnostics"))]
-                {
-                    let _ = dispatch;
-                }
-            }
+        if result.final_chunk {
+            *in_flight = in_flight.saturating_sub(1);
         }
+        let current = state.tide_republish_lane_generation() == result.generation;
+        if !current {
+            // Disowned mid-wave: nothing to queue; completion for the stale
+            // generation is a no-op on the lane and drops the leftovers.
+            if result.final_chunk {
+                let _ = complete_tide_workspace_republish(state, result.generation, Vec::new());
+            }
+            continue;
+        }
+        let active = pending.get_or_insert_with(|| PendingTideRepublishApplyV0 {
+            generation: result.generation,
+            items: std::collections::VecDeque::new(),
+            uncovered_uris: Vec::new(),
+            final_chunk_seen: false,
+        });
+        active.items.extend(result.items);
+        active.uncovered_uris.extend(result.uncovered_uris);
+        active.final_chunk_seen |= result.final_chunk;
     }
     let mut completed: Option<(u64, Vec<String>)> = None;
     if let Some(active) = pending.as_mut() {

--- a/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
+++ b/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
@@ -18,10 +18,10 @@ use omena_lsp_server::{
     apply_background_workspace_index_result, apply_deferred_external_sif_refresh_result,
     collect_background_workspace_index, collect_deferred_external_sif_refresh,
     dispatched_query_internal_error_response, enable_deferred_external_sif_refresh,
-    external_sif_refresh_follow_up_diagnostics_effects,
     handle_lsp_message_scheduled_outputs_or_dispatch,
     prepare_background_workspace_index_continuation_job, prepare_deferred_external_sif_refresh_job,
-    resolve_dispatched_query_response, workspace_index_progress_end_output,
+    resolve_dispatched_query_response, tide_workspace_republish_flush_effects,
+    workspace_index_progress_end_output,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -399,23 +399,23 @@ fn drain_external_sif_refresh_results<W: Write + Send + 'static>(
         DeferredDiagnosticsWorkV0,
     >,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut any_result_applied = false;
     while let Ok(result) = receiver.try_recv() {
         *in_flight = in_flight.saturating_sub(1);
-        any_result_applied |= apply_deferred_external_sif_refresh_result(state, result);
+        apply_deferred_external_sif_refresh_result(state, result);
     }
-    if any_result_applied {
-        let effects = external_sif_refresh_follow_up_diagnostics_effects(state);
-        for output in effects.outputs {
-            write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
-        }
-        for dispatch in effects.deferred_diagnostics {
-            #[cfg(feature = "salsa-style-diagnostics")]
-            dispatch_deferred_diagnostics(diagnostics_sender, coalescer, dispatch)?;
-            #[cfg(not(feature = "salsa-style-diagnostics"))]
-            {
-                let _ = dispatch;
-            }
+    // Gate evaluation runs every drain tick: a changed SIF apply deposits the
+    // workspace-republish demand, and settings changes deposit it from the
+    // message loop; the settle gate coalesces either into one flush.
+    let effects = tide_workspace_republish_flush_effects(state);
+    for output in effects.outputs {
+        write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
+    }
+    for dispatch in effects.deferred_diagnostics {
+        #[cfg(feature = "salsa-style-diagnostics")]
+        dispatch_deferred_diagnostics(diagnostics_sender, coalescer, dispatch)?;
+        #[cfg(not(feature = "salsa-style-diagnostics"))]
+        {
+            let _ = dispatch;
         }
     }
     Ok(())
@@ -993,11 +993,13 @@ mod tests {
 
     #[cfg(feature = "salsa-style-diagnostics")]
     fn external_sif_result(
-        revision: u64,
+        stamp: omena_lsp_server::tide::TideFootprintStampV0,
+        generation: u64,
         external_sifs: Vec<OmenaQueryExternalSifInputV0>,
     ) -> LspExternalSifRefreshResultV0 {
         LspExternalSifRefreshResultV0 {
-            revision,
+            stamp,
+            generation,
             bridge_external_sif_urls: external_sifs
                 .iter()
                 .map(|input| input.canonical_url.clone())
@@ -1038,7 +1040,8 @@ mod tests {
         let mut state = external_sif_drain_state()?;
         let job = prepare_deferred_external_sif_refresh_job(&mut state)
             .ok_or_else(|| "external SIF refresh job was not scheduled".to_string())?;
-        let revision = job.revision;
+        let stamp = job.stamp.clone();
+        let generation = job.generation;
         let inputs = vec![
             external_sif_input("a")?,
             external_sif_input("b")?,
@@ -1047,7 +1050,11 @@ mod tests {
         let (sender, receiver) = mpsc::channel();
         for index in 0..inputs.len() {
             sender
-                .send(external_sif_result(revision, inputs[..=index].to_vec()))
+                .send(external_sif_result(
+                    stamp.clone(),
+                    generation,
+                    inputs[..=index].to_vec(),
+                ))
                 .map_err(|error| error.to_string())?;
         }
         drop(sender);
@@ -1094,10 +1101,16 @@ mod tests {
             .ok_or_else(|| "reference external SIF refresh job was not scheduled".to_string())?;
         assert!(apply_deferred_external_sif_refresh_result(
             &mut reference_state,
-            external_sif_result(reference_job.revision, inputs)
+            external_sif_result(
+                reference_job.stamp.clone(),
+                reference_job.generation,
+                inputs
+            )
         ));
         let reference_effects =
-            external_sif_refresh_follow_up_diagnostics_effects(&mut reference_state);
+            omena_lsp_server::external_sif_refresh_follow_up_diagnostics_effects(
+                &mut reference_state,
+            );
         assert_eq!(reference_effects.deferred_diagnostics.len(), 1);
 
         let mut actual_host = omena_query::OmenaQueryStyleMemoHostV0::default();

--- a/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
+++ b/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
@@ -104,9 +104,13 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
     // under a per-tick chunk budget.
     #[cfg(feature = "parallel-style-diagnostics")]
     let tide_republish_worker: JoinHandle<Result<(), String>> = thread::spawn(move || {
+        let sender = Mutex::new(tide_republish_result_sender);
         while let Ok(job) = tide_republish_job_receiver.recv() {
-            collect_tide_workspace_republish_streaming(job, &mut |result| {
-                tide_republish_result_sender.send(result).is_ok()
+            collect_tide_workspace_republish_streaming(job, &|result| {
+                sender
+                    .lock()
+                    .map(|sender| sender.send(result).is_ok())
+                    .unwrap_or(false)
             });
         }
         Ok(())

--- a/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
+++ b/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use std::time::Instant;
 use std::{collections::BTreeMap, sync::MutexGuard};
 
+#[cfg(not(feature = "parallel-style-diagnostics"))]
+use omena_lsp_server::tide_workspace_republish_flush_effects;
 #[cfg(feature = "salsa-style-diagnostics")]
 use omena_lsp_server::{
     LspDeferredDiagnosticsDispatchV0, OPTIMIZING_DIAGNOSTICS_DELAY_MS,
@@ -20,8 +22,13 @@ use omena_lsp_server::{
     dispatched_query_internal_error_response, enable_deferred_external_sif_refresh,
     handle_lsp_message_scheduled_outputs_or_dispatch,
     prepare_background_workspace_index_continuation_job, prepare_deferred_external_sif_refresh_job,
-    resolve_dispatched_query_response, tide_workspace_republish_flush_effects,
-    workspace_index_progress_end_output,
+    resolve_dispatched_query_response, workspace_index_progress_end_output,
+};
+#[cfg(feature = "parallel-style-diagnostics")]
+use omena_lsp_server::{
+    TideWorkspaceRepublishItemV0, TideWorkspaceRepublishJobV0, TideWorkspaceRepublishResultV0,
+    apply_tide_workspace_republish_item, collect_tide_workspace_republish,
+    complete_tide_workspace_republish, prepare_tide_workspace_republish_job,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -83,6 +90,25 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
             external_sif_refresh_result_sender
                 .send(result)
                 .map_err(|_| "external SIF refresh result receiver dropped".to_string())?;
+        }
+        Ok(())
+    });
+    #[cfg(feature = "parallel-style-diagnostics")]
+    let (tide_republish_job_sender, tide_republish_job_receiver) =
+        mpsc::channel::<TideWorkspaceRepublishJobV0>();
+    #[cfg(feature = "parallel-style-diagnostics")]
+    let (tide_republish_result_sender, tide_republish_result_receiver) =
+        mpsc::channel::<TideWorkspaceRepublishResultV0>();
+    // rfcs#111 §8.5: the IdleLane executor — the wave runs off-loop against a
+    // query snapshot; publish applies flow back and are pumped loop-side
+    // under a per-tick chunk budget.
+    #[cfg(feature = "parallel-style-diagnostics")]
+    let tide_republish_worker: JoinHandle<Result<(), String>> = thread::spawn(move || {
+        while let Ok(job) = tide_republish_job_receiver.recv() {
+            let result = collect_tide_workspace_republish(job);
+            tide_republish_result_sender
+                .send(result)
+                .map_err(|_| "tide republish result receiver dropped".to_string())?;
         }
         Ok(())
     });
@@ -207,7 +233,14 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
     let mut input_closed = false;
     let mut workspace_index_in_flight = 0usize;
     let mut external_sif_refresh_in_flight = 0usize;
+    #[cfg(feature = "parallel-style-diagnostics")]
+    let mut tide_republish_in_flight = 0usize;
+    #[cfg(feature = "parallel-style-diagnostics")]
+    let mut tide_republish_apply: Option<PendingTideRepublishApplyV0> = None;
+    #[cfg(feature = "parallel-style-diagnostics")]
+    let mut last_client_message_at = Instant::now();
     loop {
+        state.advance_tide_tick();
         drain_workspace_index_results(
             &mut state,
             &workspace_index_result_receiver,
@@ -232,6 +265,27 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
             &external_sif_refresh_sender,
             &mut external_sif_refresh_in_flight,
         )?;
+        #[cfg(feature = "parallel-style-diagnostics")]
+        {
+            drain_and_pump_tide_republish(
+                &mut state,
+                &tide_republish_result_receiver,
+                &mut tide_republish_in_flight,
+                &mut tide_republish_apply,
+                &writer,
+                &coalescer,
+                &mut delayed_outputs,
+                #[cfg(feature = "salsa-style-diagnostics")]
+                &diagnostics_sender,
+            )?;
+            let idle = last_client_message_at.elapsed() >= Duration::from_millis(300);
+            dispatch_tide_workspace_republish_if_needed(
+                &mut state,
+                &tide_republish_job_sender,
+                &mut tide_republish_in_flight,
+                idle,
+            )?;
+        }
         #[cfg(feature = "salsa-style-diagnostics")]
         drain_deferred_diagnostics_completions(&diagnostics_completion_receiver);
         if input_closed {
@@ -254,6 +308,10 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
                 continue;
             }
         };
+        #[cfg(feature = "parallel-style-diagnostics")]
+        {
+            last_client_message_at = Instant::now();
+        }
         let message: serde_json::Value = serde_json::from_str(&payload)?;
         match handle_lsp_message_scheduled_outputs_or_dispatch(&mut state, message) {
             LspLoopTurnV0::DispatchQuery(dispatch) => {
@@ -325,6 +383,8 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
     drop(query_sender);
     drop(workspace_index_sender);
     drop(external_sif_refresh_sender);
+    #[cfg(feature = "parallel-style-diagnostics")]
+    drop(tide_republish_job_sender);
     #[cfg(feature = "salsa-style-diagnostics")]
     drop(diagnostics_sender);
     #[cfg(feature = "salsa-style-diagnostics")]
@@ -337,6 +397,11 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
         .join()
         .map_err(|_| "external SIF refresh worker panicked".to_string())?
         .map_err(|error| format!("external SIF refresh worker failed: {error}"))?;
+    #[cfg(feature = "parallel-style-diagnostics")]
+    tide_republish_worker
+        .join()
+        .map_err(|_| "tide republish worker panicked".to_string())?
+        .map_err(|error| format!("tide republish worker failed: {error}"))?;
     query_worker
         .join()
         .map_err(|_| "query worker panicked".to_string())?
@@ -354,6 +419,127 @@ fn run_stdio_server<R: BufRead + Send + 'static, W: Write + Send + 'static>(
             .join()
             .map_err(|_| "delayed LSP writer panicked".to_string())?
             .map_err(|error| format!("delayed LSP writer failed: {error}"))?;
+    }
+    Ok(())
+}
+
+/// Loop-side pending applies of one republish tide (rfcs#111 §8.5): pumped
+/// a bounded chunk per tick so the loop never stalls behind a bulk apply.
+#[cfg(feature = "parallel-style-diagnostics")]
+struct PendingTideRepublishApplyV0 {
+    generation: u64,
+    items: std::collections::VecDeque<TideWorkspaceRepublishItemV0>,
+    uncovered_uris: Vec<String>,
+}
+
+#[cfg(feature = "parallel-style-diagnostics")]
+const TIDE_REPUBLISH_APPLY_CHUNK: usize = 8;
+
+#[cfg(feature = "parallel-style-diagnostics")]
+fn dispatch_tide_workspace_republish_if_needed(
+    state: &mut LspShellState,
+    sender: &mpsc::Sender<TideWorkspaceRepublishJobV0>,
+    in_flight: &mut usize,
+    idle: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if *in_flight > 0 {
+        return Ok(());
+    }
+    let Some(job) = prepare_tide_workspace_republish_job(state, idle) else {
+        return Ok(());
+    };
+    sender
+        .send(job)
+        .map_err(|_| "tide republish worker exited before shutdown")?;
+    *in_flight = in_flight.saturating_add(1);
+    Ok(())
+}
+
+#[cfg(feature = "parallel-style-diagnostics")]
+fn drain_and_pump_tide_republish<W: Write + Send + 'static>(
+    state: &mut LspShellState,
+    receiver: &mpsc::Receiver<TideWorkspaceRepublishResultV0>,
+    in_flight: &mut usize,
+    pending: &mut Option<PendingTideRepublishApplyV0>,
+    writer: &Arc<Mutex<W>>,
+    coalescer: &Arc<Mutex<ScheduledOutputCoalescer>>,
+    delayed_outputs: &mut Vec<JoinHandle<Result<(), String>>>,
+    #[cfg(feature = "salsa-style-diagnostics")] diagnostics_sender: &mpsc::SyncSender<
+        DeferredDiagnosticsWorkV0,
+    >,
+) -> Result<(), Box<dyn std::error::Error>> {
+    while let Ok(result) = receiver.try_recv() {
+        *in_flight = in_flight.saturating_sub(1);
+        let current = state.tide_republish_lane_generation() == result.generation;
+        if current && !result.items.is_empty() {
+            *pending = Some(PendingTideRepublishApplyV0 {
+                generation: result.generation,
+                items: result.items.into(),
+                uncovered_uris: result.uncovered_uris,
+            });
+        } else {
+            // Disowned mid-wave, or nothing covered: complete now. A CURRENT
+            // empty wave still owes its uncovered targets to the fallback arm.
+            let uncovered_uris = if current {
+                result.uncovered_uris
+            } else {
+                Vec::new()
+            };
+            let effects =
+                complete_tide_workspace_republish(state, result.generation, uncovered_uris);
+            for output in effects.outputs {
+                write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
+            }
+            for dispatch in effects.deferred_diagnostics {
+                #[cfg(feature = "salsa-style-diagnostics")]
+                dispatch_deferred_diagnostics(diagnostics_sender, coalescer, dispatch)?;
+                #[cfg(not(feature = "salsa-style-diagnostics"))]
+                {
+                    let _ = dispatch;
+                }
+            }
+        }
+    }
+    let mut completed: Option<(u64, Vec<String>)> = None;
+    if let Some(active) = pending.as_mut() {
+        if state.tide_republish_lane_generation() != active.generation {
+            // The settle window reopened while applies were pending: drop the
+            // stale items — the reopened window's tide republishes their keys
+            // and the publication order key forbids stale overwrites.
+            completed = Some((active.generation, Vec::new()));
+        } else {
+            let mut applied = 0usize;
+            while applied < TIDE_REPUBLISH_APPLY_CHUNK {
+                let Some(item) = active.items.pop_front() else {
+                    break;
+                };
+                for output in apply_tide_workspace_republish_item(state, item) {
+                    write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
+                }
+                applied = applied.saturating_add(1);
+            }
+            if active.items.is_empty() {
+                completed = Some((
+                    active.generation,
+                    std::mem::take(&mut active.uncovered_uris),
+                ));
+            }
+        }
+    }
+    if let Some((generation, uncovered_uris)) = completed {
+        *pending = None;
+        let effects = complete_tide_workspace_republish(state, generation, uncovered_uris);
+        for output in effects.outputs {
+            write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
+        }
+        for dispatch in effects.deferred_diagnostics {
+            #[cfg(feature = "salsa-style-diagnostics")]
+            dispatch_deferred_diagnostics(diagnostics_sender, coalescer, dispatch)?;
+            #[cfg(not(feature = "salsa-style-diagnostics"))]
+            {
+                let _ = dispatch;
+            }
+        }
     }
     Ok(())
 }
@@ -403,20 +589,29 @@ fn drain_external_sif_refresh_results<W: Write + Send + 'static>(
         *in_flight = in_flight.saturating_sub(1);
         apply_deferred_external_sif_refresh_result(state, result);
     }
-    // Gate evaluation runs every drain tick: a changed SIF apply deposits the
-    // workspace-republish demand, and settings changes deposit it from the
-    // message loop; the settle gate coalesces either into one flush.
-    let effects = tide_workspace_republish_flush_effects(state);
-    for output in effects.outputs {
-        write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
-    }
-    for dispatch in effects.deferred_diagnostics {
-        #[cfg(feature = "salsa-style-diagnostics")]
-        dispatch_deferred_diagnostics(diagnostics_sender, coalescer, dispatch)?;
-        #[cfg(not(feature = "salsa-style-diagnostics"))]
-        {
-            let _ = dispatch;
+    // Under the parallel wave feature the workspace republish flows through
+    // the off-loop tide executor (rfcs#111 §12 M3); other builds keep the
+    // loop-side per-file deferred flush.
+    #[cfg(not(feature = "parallel-style-diagnostics"))]
+    {
+        let effects = tide_workspace_republish_flush_effects(state);
+        for output in effects.outputs {
+            write_scheduled_lsp_output(writer, coalescer, output, delayed_outputs)?;
         }
+        for dispatch in effects.deferred_diagnostics {
+            #[cfg(feature = "salsa-style-diagnostics")]
+            dispatch_deferred_diagnostics(diagnostics_sender, coalescer, dispatch)?;
+            #[cfg(not(feature = "salsa-style-diagnostics"))]
+            {
+                let _ = dispatch;
+            }
+        }
+    }
+    #[cfg(feature = "parallel-style-diagnostics")]
+    {
+        let _ = (writer, coalescer, delayed_outputs);
+        #[cfg(feature = "salsa-style-diagnostics")]
+        let _ = diagnostics_sender;
     }
     Ok(())
 }
@@ -1076,6 +1271,15 @@ mod tests {
             &diagnostics_sender,
         )
         .map_err(|error| error.to_string())?;
+        // Under the M3 executor the drain only applies results and deposits
+        // the republish demand; the gate flush is the loop's business. Drive
+        // it here the way the loop does and route its per-file fallback arm
+        // through the diagnostics channel to count the waves of the K-burst.
+        let flush_effects = omena_lsp_server::tide_workspace_republish_flush_effects(&mut state);
+        for dispatch in flush_effects.deferred_diagnostics {
+            dispatch_deferred_diagnostics(&diagnostics_sender, &coalescer, dispatch)
+                .map_err(|error| error.to_string())?;
+        }
         drop(diagnostics_sender);
 
         assert_eq!(in_flight, 0);

--- a/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
@@ -1,7 +1,15 @@
 use crate::diagnostics_scheduler;
 use crate::lsp_output::{LspDeferredDiagnosticsDispatchV0, ScheduledLspOutput};
 use crate::protocol::is_style_document_uri;
+use crate::tide::{TideGateInputsV0, TideLaneConfigV0};
 use crate::{LspDocumentOrigin, LspExternalSifRefreshResultV0, LspShellState};
+
+/// The workspace-republish lane flushes on frontier passage; M2 pins the
+/// courtesy layer open to preserve the pre-Tide follow-up timing (real
+/// idleness plus aging is the M3 executor's business — rfcs#111 §12).
+pub(crate) const TIDE_REPUBLISH_LANE_CONFIG: TideLaneConfigV0 = TideLaneConfigV0 {
+    aging_bound_ticks: u64::MAX,
+};
 
 #[cfg(test)]
 pub(crate) mod warmup_wave_count_probe {
@@ -65,9 +73,38 @@ pub fn apply_external_sif_refresh_result_follow_up_diagnostics_effects(
     state: &mut LspShellState,
     result: LspExternalSifRefreshResultV0,
 ) -> LspDiagnosticsFollowUpEffectsV0 {
-    if crate::apply_deferred_external_sif_refresh_result(state, result) {
-        external_sif_refresh_follow_up_diagnostics_effects(state)
-    } else {
-        LspDiagnosticsFollowUpEffectsV0::default()
-    }
+    crate::apply_deferred_external_sif_refresh_result(state, result);
+    tide_workspace_republish_flush_effects(state)
+}
+
+/// The republish frontier: the SIF lane is fully settled — no undrained
+/// demand, no in-flight tide — and no index chain is mid-flight. A republish
+/// computed before that point would present a corpus state that is invalid
+/// as a final (rfcs#111 P2).
+fn workspace_republish_frontier_passed(state: &LspShellState) -> bool {
+    !state.tide_sif_lane.has_demand()
+        && !state.tide_sif_lane.in_flight()
+        && state.workspace_index_pending_file_count == 0
+}
+
+/// Evaluate the workspace-republish settle gate; on flush, run the follow-up
+/// executor. M2 keeps the per-file deferred executor verbatim and completes
+/// the tide at flush time — the executor swap to the off-loop generation-
+/// checked wave is exclusively M3 (rfcs#111 §12).
+pub fn tide_workspace_republish_flush_effects(
+    state: &mut LspShellState,
+) -> LspDiagnosticsFollowUpEffectsV0 {
+    let inputs = TideGateInputsV0 {
+        frontier_passed: workspace_republish_frontier_passed(state),
+        idle: true,
+    };
+    let Some(flush) = state
+        .tide_republish_lane
+        .try_flush(inputs, 0, &TIDE_REPUBLISH_LANE_CONFIG)
+    else {
+        return LspDiagnosticsFollowUpEffectsV0::default();
+    };
+    let effects = external_sif_refresh_follow_up_diagnostics_effects(state);
+    state.tide_republish_lane.tide_completed(flush.generation);
+    effects
 }

--- a/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
@@ -4,11 +4,11 @@ use crate::protocol::is_style_document_uri;
 use crate::tide::{TideGateInputsV0, TideLaneConfigV0};
 use crate::{LspDocumentOrigin, LspExternalSifRefreshResultV0, LspShellState};
 
-/// The workspace-republish lane flushes on frontier passage; M2 pins the
-/// courtesy layer open to preserve the pre-Tide follow-up timing (real
-/// idleness plus aging is the M3 executor's business — rfcs#111 §12).
+/// The workspace-republish lane: the M3 executor passes real idleness for
+/// the courtesy layer; aging (~10s at the 5ms tick) overrides courtesy so a
+/// busy editor still converges. The correctness layer is never overridden.
 pub(crate) const TIDE_REPUBLISH_LANE_CONFIG: TideLaneConfigV0 = TideLaneConfigV0 {
-    aging_bound_ticks: u64::MAX,
+    aging_bound_ticks: 2_000,
 };
 
 #[cfg(test)]
@@ -81,7 +81,7 @@ pub fn apply_external_sif_refresh_result_follow_up_diagnostics_effects(
 /// demand, no in-flight tide — and no index chain is mid-flight. A republish
 /// computed before that point would present a corpus state that is invalid
 /// as a final (rfcs#111 P2).
-fn workspace_republish_frontier_passed(state: &LspShellState) -> bool {
+pub(crate) fn workspace_republish_frontier_passed(state: &LspShellState) -> bool {
     !state.tide_sif_lane.has_demand()
         && !state.tide_sif_lane.in_flight()
         && state.workspace_index_pending_file_count == 0
@@ -98,9 +98,10 @@ pub fn tide_workspace_republish_flush_effects(
         frontier_passed: workspace_republish_frontier_passed(state),
         idle: true,
     };
-    let Some(flush) = state
-        .tide_republish_lane
-        .try_flush(inputs, 0, &TIDE_REPUBLISH_LANE_CONFIG)
+    let Some(flush) =
+        state
+            .tide_republish_lane
+            .try_flush(inputs, state.tide_tick, &TIDE_REPUBLISH_LANE_CONFIG)
     else {
         return LspDiagnosticsFollowUpEffectsV0::default();
     };

--- a/rust/crates/omena-lsp-server/src/diagnostics_scheduler.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_scheduler.rs
@@ -565,7 +565,7 @@ enum DiagnosticsPipelineTier {
     Optimizing,
 }
 
-fn publish_tiered_diagnostics_notifications(
+pub(crate) fn publish_tiered_diagnostics_notifications(
     state: &mut LspShellState,
     uri: &str,
     diagnostics: Value,

--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -200,7 +200,7 @@ pub(crate) fn disk_diagnostics_cache_key_v0(
 /// One resolved cache placement: directory + composite key + target. Built
 /// before the workspace diagnostics compute; `load` is the exact-match read
 /// path and `store_write_behind` persists the computed result.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct DiskDiagnosticsCacheSlotV0 {
     dir: PathBuf,
     key: String,

--- a/rust/crates/omena-lsp-server/src/external_sif_loader.rs
+++ b/rust/crates/omena-lsp-server/src/external_sif_loader.rs
@@ -66,7 +66,8 @@ pub(crate) const TIDE_SETTLE_LANE_CONFIG: TideLaneConfigV0 = TideLaneConfigV0 {
 pub(crate) fn refresh_external_sifs_for_state(state: &mut LspShellState) {
     if state.external_sif_refresh_deferred {
         crate::loop_trace!("sif-demand reason=state-refresh");
-        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, 0);
+        let tick = state.tide_tick;
+        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, tick);
         return;
     }
     refresh_external_sifs_for_state_immediate(state);
@@ -128,7 +129,9 @@ pub(crate) fn refresh_external_sifs_for_bridge_source_delta(
         // stales any in-flight SIF job (footprint member) and deposits the
         // demand whose tide will re-resolve against the new topology.
         state.tide_ledger.advance(&[TideInputKindV0::DocumentSet]);
-        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, 0);
+        state.tide_reopen_republish_window();
+        let tick = state.tide_tick;
+        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, tick);
         return;
     }
     let previous_sources = previous_sources.iter().cloned().collect::<BTreeSet<_>>();
@@ -223,7 +226,8 @@ pub(crate) fn bridge_sources_for_style_uris(
 
 pub fn enable_deferred_external_sif_refresh(state: &mut LspShellState) {
     state.external_sif_refresh_deferred = true;
-    state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, 0);
+    let tick = state.tide_tick;
+    state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, tick);
 }
 
 pub fn prepare_deferred_external_sif_refresh_job(
@@ -241,7 +245,7 @@ pub fn prepare_deferred_external_sif_refresh_job(
     };
     let flush = state
         .tide_sif_lane
-        .try_flush(inputs, 0, &TIDE_SETTLE_LANE_CONFIG)?;
+        .try_flush(inputs, state.tide_tick, &TIDE_SETTLE_LANE_CONFIG)?;
     crate::loop_trace!(
         "sif-job-prepared gen={} epoch={} docs={}",
         flush.generation,
@@ -346,9 +350,11 @@ pub fn apply_deferred_external_sif_refresh_result(
         invalidate_external_sif_dependents(state);
         // Output cutoff (rfcs#111 §4.1): only a CHANGED SIF set owes the
         // workspace republish; an Eq result blocks downstream entirely.
+        state.tide_reopen_republish_window();
+        let tick = state.tide_tick;
         state
             .tide_republish_lane
-            .deposit(TideDemandV0::WorkspaceRepublish, 0);
+            .deposit(TideDemandV0::WorkspaceRepublish, tick);
     }
     state.resolution.bridge_external_sif_urls = result.bridge_external_sif_urls;
     state.tide_sif_lane.tide_completed(result.generation);

--- a/rust/crates/omena-lsp-server/src/external_sif_loader.rs
+++ b/rust/crates/omena-lsp-server/src/external_sif_loader.rs
@@ -1,4 +1,8 @@
 use crate::protocol::{file_uri_to_path, is_style_document_uri, normalize_path};
+use crate::tide::{
+    TideDemandV0, TideFootprintStampV0, TideFootprintV0, TideGateInputsV0, TideInputKindV0,
+    TideLaneConfigV0,
+};
 use crate::{LspShellState, LspTextDocumentState};
 use omena_query::{
     OmenaQueryBridgeExternalSifResolutionV0, OmenaQueryExternalSifInputV0,
@@ -22,7 +26,8 @@ pub struct LspExternalSifRefreshDocumentV0 {
 
 #[derive(Debug, Clone)]
 pub struct LspExternalSifRefreshJobV0 {
-    pub revision: u64,
+    pub stamp: TideFootprintStampV0,
+    pub generation: u64,
     pub lockfiles: Vec<PathBuf>,
     pub documents: Vec<LspExternalSifRefreshDocumentV0>,
     pub package_manifests: Vec<omena_query::OmenaQueryStylePackageManifestV0>,
@@ -32,20 +37,36 @@ pub struct LspExternalSifRefreshJobV0 {
 
 #[derive(Debug, Clone)]
 pub struct LspExternalSifRefreshResultV0 {
-    pub revision: u64,
+    pub stamp: TideFootprintStampV0,
+    pub generation: u64,
     pub external_sifs: Vec<OmenaQueryExternalSifInputV0>,
     pub bridge_external_sif_urls: BTreeSet<String>,
     pub lock_read_count: usize,
     pub bridge_generation_count: usize,
 }
 
+/// The SIF job's declared input footprint (rfcs#111 §4.1). DocumentText is
+/// deliberately absent: text edits reach SIF resolution through the
+/// bridge-source delta path, which deposits a NEW demand instead of staling
+/// the in-flight job — an unfootprinted clock would discard in-flight work
+/// on every keystroke (the review BLOCKER).
+pub(crate) const EXTERNAL_SIF_FOOTPRINT: TideFootprintV0 = TideFootprintV0::of(&[
+    TideInputKindV0::DocumentSet,
+    TideInputKindV0::LockfileFingerprint,
+    TideInputKindV0::PackageManifest,
+    TideInputKindV0::ResolutionSettings,
+]);
+
+/// SettleGated lanes flush on frontier passage alone: the courtesy layer is
+/// pinned open, so the aging bound is never consulted.
+pub(crate) const TIDE_SETTLE_LANE_CONFIG: TideLaneConfigV0 = TideLaneConfigV0 {
+    aging_bound_ticks: u64::MAX,
+};
+
 pub(crate) fn refresh_external_sifs_for_state(state: &mut LspShellState) {
     if state.external_sif_refresh_deferred {
-        crate::loop_trace!(
-            "sif-dirty reason=state-refresh rev->{}",
-            state.external_sif_refresh_revision + 1
-        );
-        mark_external_sif_refresh_dirty(state);
+        crate::loop_trace!("sif-demand reason=state-refresh");
+        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, 0);
         return;
     }
     refresh_external_sifs_for_state_immediate(state);
@@ -93,18 +114,21 @@ pub(crate) fn refresh_external_sifs_for_bridge_source_delta(
         let next_set = next_sources.iter().collect::<BTreeSet<_>>();
         if previous_set == next_set {
             crate::loop_trace!(
-                "sif-dirty SKIPPED reason=bridge-delta-equal len={}",
+                "sif-demand SKIPPED reason=bridge-delta-equal len={}",
                 next_set.len()
             );
             return;
         }
         crate::loop_trace!(
-            "sif-dirty reason=bridge-delta prev={} next={} rev->{}",
+            "sif-demand reason=bridge-delta prev={} next={}",
             previous_sources.len(),
-            next_sources.len(),
-            state.external_sif_refresh_revision + 1
+            next_sources.len()
         );
-        mark_external_sif_refresh_dirty(state);
+        // A genuine bridge-topology change is a corpus-input mutation: it
+        // stales any in-flight SIF job (footprint member) and deposits the
+        // demand whose tide will re-resolve against the new topology.
+        state.tide_ledger.advance(&[TideInputKindV0::DocumentSet]);
+        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, 0);
         return;
     }
     let previous_sources = previous_sources.iter().cloned().collect::<BTreeSet<_>>();
@@ -199,19 +223,29 @@ pub(crate) fn bridge_sources_for_style_uris(
 
 pub fn enable_deferred_external_sif_refresh(state: &mut LspShellState) {
     state.external_sif_refresh_deferred = true;
-    mark_external_sif_refresh_dirty(state);
+    state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, 0);
 }
 
 pub fn prepare_deferred_external_sif_refresh_job(
     state: &mut LspShellState,
 ) -> Option<LspExternalSifRefreshJobV0> {
-    if !state.external_sif_refresh_deferred || !state.external_sif_refresh_dirty {
+    if !state.external_sif_refresh_deferred {
         return None;
     }
-    state.external_sif_refresh_dirty = false;
+    // Settle gate: the correctness layer is the index frontier — no flush
+    // while an index chain still has pending files. The lane enforces one
+    // in-flight tide, so a second prepare during a running job is a no-op.
+    let inputs = TideGateInputsV0 {
+        frontier_passed: state.workspace_index_pending_file_count == 0,
+        idle: true,
+    };
+    let flush = state
+        .tide_sif_lane
+        .try_flush(inputs, 0, &TIDE_SETTLE_LANE_CONFIG)?;
     crate::loop_trace!(
-        "sif-job-prepared rev={} docs={}",
-        state.external_sif_refresh_revision,
+        "sif-job-prepared gen={} epoch={} docs={}",
+        flush.generation,
+        state.tide_ledger.epoch(),
         state
             .documents
             .values()
@@ -219,7 +253,8 @@ pub fn prepare_deferred_external_sif_refresh_job(
             .count()
     );
     Some(LspExternalSifRefreshJobV0 {
-        revision: state.external_sif_refresh_revision,
+        stamp: state.tide_ledger.stamp(EXTERNAL_SIF_FOOTPRINT),
+        generation: flush.generation,
         lockfiles: workspace_lockfiles(state),
         documents: state
             .documents
@@ -267,7 +302,8 @@ pub fn collect_deferred_external_sif_refresh(
     );
 
     LspExternalSifRefreshResultV0 {
-        revision: job.revision,
+        stamp: job.stamp,
+        generation: job.generation,
         external_sifs,
         bridge_external_sif_urls: bridge_result.bridge_urls.into_iter().collect(),
         lock_read_count,
@@ -279,12 +315,16 @@ pub fn apply_deferred_external_sif_refresh_result(
     state: &mut LspShellState,
     result: LspExternalSifRefreshResultV0,
 ) -> bool {
-    if result.revision != state.external_sif_refresh_revision {
+    if !state.tide_ledger.is_current(&result.stamp) {
         crate::loop_trace!(
-            "sif-apply DISCARDED result_rev={} state_rev={}",
-            result.revision,
-            state.external_sif_refresh_revision
+            "sif-apply DISCARDED gen={} stamp_epoch={} ledger_epoch={}",
+            result.generation,
+            result.stamp.epoch,
+            state.tide_ledger.epoch()
         );
+        // The staling mutation also deposited a fresh demand (every advance
+        // site deposits), so completing the disowned tide re-arms the gate.
+        state.tide_sif_lane.tide_completed(result.generation);
         return false;
     }
     state.external_sif_lock_read_count = state
@@ -295,8 +335,8 @@ pub fn apply_deferred_external_sif_refresh_result(
         .saturating_add(result.bridge_generation_count);
     let changed = state.resolution.external_sifs != result.external_sifs;
     crate::loop_trace!(
-        "sif-apply rev={} changed={} sifs {}->{}",
-        result.revision,
+        "sif-apply gen={} changed={} sifs {}->{}",
+        result.generation,
         changed,
         state.resolution.external_sifs.len(),
         result.external_sifs.len()
@@ -304,14 +344,15 @@ pub fn apply_deferred_external_sif_refresh_result(
     if changed {
         state.resolution.external_sifs = result.external_sifs;
         invalidate_external_sif_dependents(state);
+        // Output cutoff (rfcs#111 §4.1): only a CHANGED SIF set owes the
+        // workspace republish; an Eq result blocks downstream entirely.
+        state
+            .tide_republish_lane
+            .deposit(TideDemandV0::WorkspaceRepublish, 0);
     }
     state.resolution.bridge_external_sif_urls = result.bridge_external_sif_urls;
+    state.tide_sif_lane.tide_completed(result.generation);
     changed
-}
-
-fn mark_external_sif_refresh_dirty(state: &mut LspShellState) {
-    state.external_sif_refresh_revision = state.external_sif_refresh_revision.saturating_add(1);
-    state.external_sif_refresh_dirty = true;
 }
 
 fn workspace_lockfiles(state: &LspShellState) -> Vec<PathBuf> {

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -38,7 +38,7 @@ mod style_hover_markdown;
 mod style_symbol_monikers;
 mod style_symbol_occurrence_cache;
 mod style_symbol_provider;
-pub(crate) mod tide;
+pub mod tide;
 mod workspace_index;
 mod workspace_occurrence_cache;
 mod workspace_occurrences;

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -212,7 +212,7 @@ pub(crate) use style_symbol_provider::{
 #[cfg(feature = "parallel-style-diagnostics")]
 pub use tide_republish::{
     TideWorkspaceRepublishItemV0, TideWorkspaceRepublishJobV0, TideWorkspaceRepublishResultV0,
-    apply_tide_workspace_republish_item, collect_tide_workspace_republish,
+    apply_tide_workspace_republish_item, collect_tide_workspace_republish_streaming,
     complete_tide_workspace_republish, prepare_tide_workspace_republish_job,
 };
 pub(crate) use workspace_index::index_workspace_style_files;

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -185,13 +185,11 @@ pub use state::*;
 use std::{collections::BTreeSet, fs, sync::Arc};
 use streaming_ifds_diagnostics::summarize_cross_file_streaming_reachability_diagnostics_for_lsp;
 #[cfg(feature = "salsa-style-diagnostics")]
+pub(crate) use style_diagnostics::LspStyleDiagnosticsRenderInputsV0;
+#[cfg(feature = "salsa-style-diagnostics")]
 pub use style_diagnostics::resolve_deferred_diagnostics_notification;
 #[cfg(test)]
 pub(crate) use style_diagnostics::resolve_style_diagnostics_for_uri;
-#[cfg(feature = "salsa-style-diagnostics")]
-pub(crate) use style_diagnostics::{
-    LspStyleDiagnosticsRenderInputsV0, finish_style_diagnostics_value,
-};
 pub(crate) use style_diagnostics::{
     lsp_diagnostic_severity, prepare_deferred_style_diagnostics_for_uri,
     resolve_document_diagnostics_for_uri, resolve_style_diagnostics,

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -39,6 +39,8 @@ mod style_symbol_monikers;
 mod style_symbol_occurrence_cache;
 mod style_symbol_provider;
 pub mod tide;
+#[cfg(feature = "parallel-style-diagnostics")]
+mod tide_republish;
 mod workspace_index;
 mod workspace_occurrence_cache;
 mod workspace_occurrences;
@@ -206,6 +208,12 @@ pub(crate) use style_symbol_provider::{
     style_symbol_definition_locations_from_documents,
     style_symbol_reference_locations_from_documents,
     style_symbol_workspace_occurrences_for_document, unapply_sass_forward_prefix,
+};
+#[cfg(feature = "parallel-style-diagnostics")]
+pub use tide_republish::{
+    TideWorkspaceRepublishItemV0, TideWorkspaceRepublishJobV0, TideWorkspaceRepublishResultV0,
+    apply_tide_workspace_republish_item, collect_tide_workspace_republish,
+    complete_tide_workspace_republish, prepare_tide_workspace_republish_job,
 };
 pub(crate) use workspace_index::index_workspace_style_files;
 pub(crate) use workspace_index::workspace_index_language_id_for_uri;

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -38,6 +38,7 @@ mod style_hover_markdown;
 mod style_symbol_monikers;
 mod style_symbol_occurrence_cache;
 mod style_symbol_provider;
+pub(crate) mod tide;
 mod workspace_index;
 mod workspace_occurrence_cache;
 mod workspace_occurrences;

--- a/rust/crates/omena-lsp-server/src/message_loop.rs
+++ b/rust/crates/omena-lsp-server/src/message_loop.rs
@@ -214,9 +214,10 @@ fn did_change_configuration(state: &mut LspShellState, params: Option<&Value>) {
         state
             .tide_ledger
             .advance(&[crate::tide::TideInputKindV0::DiagnosticSettings]);
+        let tick = state.tide_tick;
         state
             .tide_republish_lane
-            .deposit(crate::tide::TideDemandV0::WorkspaceRepublish, 0);
+            .deposit(crate::tide::TideDemandV0::WorkspaceRepublish, tick);
     }
     if apply_resolution_settings(state, settings.get("resolution")) {
         state

--- a/rust/crates/omena-lsp-server/src/message_loop.rs
+++ b/rust/crates/omena-lsp-server/src/message_loop.rs
@@ -206,8 +206,22 @@ fn did_change_configuration(state: &mut LspShellState, params: Option<&Value>) {
         return;
     };
     apply_feature_settings(state, settings.get("features"));
-    apply_diagnostic_settings(state, settings.get("diagnostics"));
+    if apply_diagnostic_settings(state, settings.get("diagnostics")) {
+        // Changed diagnostics settings owe a workspace republish: published
+        // diagnostics must re-render under the new severity / deep-analysis
+        // settings instead of staying stale indefinitely (rfcs#111 §2, the
+        // config-staleness fix). Settings-Eq changes cut off above.
+        state
+            .tide_ledger
+            .advance(&[crate::tide::TideInputKindV0::DiagnosticSettings]);
+        state
+            .tide_republish_lane
+            .deposit(crate::tide::TideDemandV0::WorkspaceRepublish, 0);
+    }
     if apply_resolution_settings(state, settings.get("resolution")) {
+        state
+            .tide_ledger
+            .advance(&[crate::tide::TideInputKindV0::ResolutionSettings]);
         refresh_source_indexes_for_resolution_settings_change(state);
     }
 }

--- a/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
+++ b/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
@@ -360,18 +360,21 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
     let committed_graph = std::sync::Arc::new(sync.committed_graph.clone());
     let resolver_identity_index =
         resolver_identity_index_for_parallel_style_wave(state, shared_surface.as_ref());
-    // rfcs#111, the first C1 slice: hoist the target-INDEPENDENT work out of
-    // the per-target loop — the corpus + diagnostics-substrate clones and
-    // the hypergraph SCC condensation are identical across every target of a
-    // wave, so they are built ONCE here and shared behind Arcs. Both arms
-    // are byte-identical to the per-target builds (same collectors; parity
-    // gates in omena-streaming-ifds and the wave-vs-serial oracle).
+    // rfcs#111 C1 slices 1+2: hoist the target-INDEPENDENT work out of the
+    // per-target loop — the corpus + diagnostics-substrate clones, the
+    // shared pass cores (source-selector usage resolution, the cross-file
+    // SCC report), and the hypergraph SCC condensation are identical across
+    // every target of a wave, so they are built ONCE here and shared behind
+    // Arcs. All arms are byte-identical to the per-target builds (same
+    // collectors; parity gates in omena-streaming-ifds and the
+    // wave-vs-serial oracle).
     let wave_substrate = {
         let db = OmenaQueryStyleMemoDatabaseV0::from_handle(sync.handle.clone());
         std::sync::Arc::new(prepare_committed_workspace_wave_substrate(
             &db,
             workspace,
             committed_graph.as_ref(),
+            Some(resolver_identity_index.as_ref()),
         ))
     };
     let shared_reachability = std::sync::Arc::new(

--- a/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
+++ b/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
@@ -156,6 +156,26 @@ pub(crate) fn resolved_parallel_style_wave_targets(
     document_uris: &[String],
     min_parallel_targets: usize,
 ) -> BTreeMap<usize, ResolvedParallelStyleTargetV0> {
+    resolved_parallel_style_wave_targets_with_abort(
+        state,
+        document_uris,
+        min_parallel_targets,
+        None,
+    )
+}
+
+/// The abort-capable arm (rfcs#111 §9.4): when `abort` is `Some`, each pool
+/// task first compares the shared generation watch against the tide's
+/// generation and returns uncovered when the settle window has reopened —
+/// item-boundary preemption, so a disowned tide stops burning the pool.
+/// Uncovered targets are the CALLER's business: the scheduler arm falls back
+/// to the serial resolve, the republish tide skips them.
+pub(crate) fn resolved_parallel_style_wave_targets_with_abort(
+    state: &LspShellState,
+    document_uris: &[String],
+    min_parallel_targets: usize,
+    abort: Option<(&std::sync::atomic::AtomicU64, u64)>,
+) -> BTreeMap<usize, ResolvedParallelStyleTargetV0> {
     let mut resolved = BTreeMap::new();
     let min_parallel_targets = min_parallel_targets.max(PARALLEL_STYLE_WAVE_MIN_PARALLEL_TARGETS);
     if parallel_style_diagnostics_kill_switch_engaged() {
@@ -324,6 +344,11 @@ pub(crate) fn resolved_parallel_style_wave_targets(
                     resolver_identity_index.clone(),
                 ),
                 |worker_state, (plan, file)| {
+                    if let Some((watch, generation)) = abort
+                        && watch.load(std::sync::atomic::Ordering::Relaxed) != generation
+                    {
+                        return None;
+                    }
                     let handle = worker_state.0.clone();
                     let committed_graph = worker_state.1.clone();
                     let resolver_identity_index = worker_state.2.clone();

--- a/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
+++ b/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
@@ -29,20 +29,20 @@ use crate::disk_cache::{
     DiskDiagnosticsCacheSlotV0, disk_diagnostics_cache_slot_for_resolve,
     is_disk_diagnostics_cache_kill_switch_value,
 };
+use crate::style_diagnostics::finish_style_diagnostics_value_with_shared_reachability;
 use crate::{
-    LspShellState, LspStyleDiagnosticsRenderInputsV0, finish_style_diagnostics_value,
-    protocol::is_style_document_uri, query_adapter::query_style_hover_candidate_from_lsp,
-    resolution_inputs_for_workspace_uri, source_documents_from_open_documents,
-    state::LspResolverIdentityIndexMemo, style_hover_candidates_for_document,
-    style_sources_from_open_documents,
+    LspShellState, LspStyleDiagnosticsRenderInputsV0, protocol::is_style_document_uri,
+    query_adapter::query_style_hover_candidate_from_lsp, resolution_inputs_for_workspace_uri,
+    source_documents_from_open_documents, state::LspResolverIdentityIndexMemo,
+    style_hover_candidates_for_document, style_sources_from_open_documents,
 };
 use omena_query::{
     OmenaQuerySourceDocumentInputV0, OmenaQueryStyleHoverCandidateV0,
     OmenaQueryStyleMemoDatabaseV0, OmenaQueryStyleMemoHostV0, OmenaQueryStyleResolutionInputsV0,
     OmenaQueryStyleSourceInputV0, OmenaResolverStyleModuleConfirmationIdentityIndexV0,
     build_omena_resolver_style_module_confirmation_identity_index,
-    omena_resolver_style_identity_generation,
-    resolve_committed_workspace_style_diagnostics_from_view_with_identity_index,
+    omena_resolver_style_identity_generation, prepare_committed_workspace_wave_substrate,
+    resolve_committed_workspace_style_diagnostics_from_view_with_identity_index_and_wave_substrate,
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde_json::Value;
@@ -164,6 +164,13 @@ pub(crate) fn resolved_parallel_style_wave_targets(
     )
 }
 
+/// Per-item sink: index into `document_uris`, the rendered diagnostics, and
+/// the write-behind slot. Called from pool threads as each target finishes —
+/// the streaming arm of the republish tide (rfcs#111 §8.5). Sink callers
+/// still receive the full result map; the sink only adds early delivery.
+pub(crate) type ParallelStyleWaveItemSinkV0<'sink> =
+    &'sink (dyn Fn(usize, Value, Option<DiskDiagnosticsCacheSlotV0>) + Sync);
+
 /// The abort-capable arm (rfcs#111 §9.4): when `abort` is `Some`, each pool
 /// task first compares the shared generation watch against the tide's
 /// generation and returns uncovered when the settle window has reopened —
@@ -175,6 +182,22 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort(
     document_uris: &[String],
     min_parallel_targets: usize,
     abort: Option<(&std::sync::atomic::AtomicU64, u64)>,
+) -> BTreeMap<usize, ResolvedParallelStyleTargetV0> {
+    resolved_parallel_style_wave_targets_with_abort_and_sink(
+        state,
+        document_uris,
+        min_parallel_targets,
+        abort,
+        None,
+    )
+}
+
+pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
+    state: &LspShellState,
+    document_uris: &[String],
+    min_parallel_targets: usize,
+    abort: Option<(&std::sync::atomic::AtomicU64, u64)>,
+    on_item: Option<ParallelStyleWaveItemSinkV0<'_>>,
 ) -> BTreeMap<usize, ResolvedParallelStyleTargetV0> {
     let mut resolved = BTreeMap::new();
     let min_parallel_targets = min_parallel_targets.max(PARALLEL_STYLE_WAVE_MIN_PARALLEL_TARGETS);
@@ -252,6 +275,9 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort(
             &surface.resolution_inputs,
         );
         if let Some(cached_diagnostics) = disk_cache_slot.as_ref().and_then(|slot| slot.load()) {
+            if let Some(sink) = on_item {
+                sink(index, cached_diagnostics.clone(), None);
+            }
             resolved.insert(
                 index,
                 ResolvedParallelStyleTargetV0 {
@@ -334,6 +360,25 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort(
     let committed_graph = std::sync::Arc::new(sync.committed_graph.clone());
     let resolver_identity_index =
         resolver_identity_index_for_parallel_style_wave(state, shared_surface.as_ref());
+    // rfcs#111, the first C1 slice: hoist the target-INDEPENDENT work out of
+    // the per-target loop — the corpus + diagnostics-substrate clones and
+    // the hypergraph SCC condensation are identical across every target of a
+    // wave, so they are built ONCE here and shared behind Arcs. Both arms
+    // are byte-identical to the per-target builds (same collectors; parity
+    // gates in omena-streaming-ifds and the wave-vs-serial oracle).
+    let wave_substrate = {
+        let db = OmenaQueryStyleMemoDatabaseV0::from_handle(sync.handle.clone());
+        std::sync::Arc::new(prepare_committed_workspace_wave_substrate(
+            &db,
+            workspace,
+            committed_graph.as_ref(),
+        ))
+    };
+    let shared_reachability = std::sync::Arc::new(
+        crate::streaming_ifds_diagnostics::shared_streaming_reachability_for_lsp(
+            &committed_graph.cross_file_summary,
+        ),
+    );
     let computed: Vec<Option<Value>> = pool.install(|| {
         pool_items
             .par_iter()
@@ -342,6 +387,8 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort(
                     sync.handle.clone(),
                     committed_graph.clone(),
                     resolver_identity_index.clone(),
+                    wave_substrate.clone(),
+                    shared_reachability.clone(),
                 ),
                 |worker_state, (plan, file)| {
                     if let Some((watch, generation)) = abort
@@ -352,20 +399,22 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort(
                     let handle = worker_state.0.clone();
                     let committed_graph = worker_state.1.clone();
                     let resolver_identity_index = worker_state.2.clone();
+                    let wave_substrate = worker_state.3.clone();
+                    let shared_reachability = worker_state.4.clone();
                     // A worker panic must not abort the wave: the target drops
                     // out of the result map and the loop recomputes it serially,
                     // panicking exactly where the serial arm would.
-                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let value = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         let db = OmenaQueryStyleMemoDatabaseV0::from_handle(handle);
                         let summary =
-                            resolve_committed_workspace_style_diagnostics_from_view_with_identity_index(
+                            resolve_committed_workspace_style_diagnostics_from_view_with_identity_index_and_wave_substrate(
                             &db,
                             workspace,
                             *file,
-                            committed_graph.as_ref(),
+                            wave_substrate.as_ref(),
                             resolver_identity_index.as_ref(),
                         );
-                        finish_style_diagnostics_value(
+                        finish_style_diagnostics_value_with_shared_reachability(
                             &LspStyleDiagnosticsRenderInputsV0 {
                                 document_uri: plan.target_uri.as_str(),
                                 document_text: plan.document_text.as_str(),
@@ -375,9 +424,14 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort(
                             },
                             summary,
                             Some(&committed_graph.cross_file_summary),
+                            Some(shared_reachability.as_ref()),
                         )
                     }))
-                    .ok()
+                    .ok();
+                    if let (Some(sink), Some(value)) = (on_item, value.as_ref()) {
+                        sink(plan.index, value.clone(), plan.disk_cache_slot.clone());
+                    }
+                    value
                 },
             )
             .collect()

--- a/rust/crates/omena-lsp-server/src/settings.rs
+++ b/rust/crates/omena-lsp-server/src/settings.rs
@@ -24,20 +24,27 @@ pub(crate) fn apply_feature_settings(state: &mut LspShellState, features: Option
     }
 }
 
-pub(crate) fn apply_diagnostic_settings(state: &mut LspShellState, diagnostics: Option<&Value>) {
+pub(crate) fn apply_diagnostic_settings(
+    state: &mut LspShellState,
+    diagnostics: Option<&Value>,
+) -> bool {
     let Some(diagnostics) = diagnostics.and_then(Value::as_object) else {
-        return;
+        return false;
     };
+    let mut changed = false;
     if let Some(value) = diagnostics
         .get("severity")
         .and_then(Value::as_str)
         .and_then(diagnostic_severity_code)
     {
+        changed |= state.diagnostics.severity != value;
         state.diagnostics.severity = value;
     }
     if let Some(value) = diagnostics.get("deepAnalysis").and_then(Value::as_bool) {
+        changed |= state.diagnostics.deep_analysis != value;
         state.diagnostics.deep_analysis = value;
     }
+    changed
 }
 
 pub(crate) fn apply_resolution_settings(

--- a/rust/crates/omena-lsp-server/src/state.rs
+++ b/rust/crates/omena-lsp-server/src/state.rs
@@ -318,6 +318,13 @@ pub struct LspShellState {
     pub(crate) tide_ledger: crate::tide::TideEpochLedgerV0,
     pub(crate) tide_sif_lane: crate::tide::TideLaneV0,
     pub(crate) tide_republish_lane: crate::tide::TideLaneV0,
+    /// Executor-visible generation watch for the republish lane: flushes
+    /// store their generation, window reopens bump it, and the off-loop wave
+    /// compares it at item boundaries to abort disowned tides (rfcs#111).
+    pub(crate) tide_republish_gen_watch: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    /// Loop tick counter consumed by lane aging; advanced once per runtime
+    /// loop iteration, stays 0 under test drivers.
+    pub(crate) tide_tick: u64,
     pub(crate) workspace_index_revision: u64,
     pub(crate) configuration_change_count: usize,
     /// RFC 0009 Pillar A (rfcs#67, slice A-min): documents are `Arc` entries so a
@@ -519,6 +526,26 @@ impl LspShellState {
     /// model for the dispatched query lane. Called on the loop thread at
     /// dispatch time; cost is O(documents) `Arc` pointer clones plus plain
     /// clones of the small settings/registry values — never a corpus deep clone.
+    /// Current republish-lane generation — the runtime loop compares queued
+    /// apply batches against it to drop disowned tides (rfcs#111 §9.4).
+    pub fn tide_republish_lane_generation(&self) -> u64 {
+        self.tide_republish_lane.generation()
+    }
+
+    /// Advance the Tide tick — called once per runtime loop iteration; the
+    /// tick feeds lane aging (courtesy-layer override, never correctness).
+    pub fn advance_tide_tick(&mut self) {
+        self.tide_tick = self.tide_tick.saturating_add(1);
+    }
+
+    /// Reopen the republish settle window: bump the lane generation (a
+    /// running tide is disowned) and publish it to the executor watch.
+    pub(crate) fn tide_reopen_republish_window(&mut self) {
+        let generation = self.tide_republish_lane.reopen_window();
+        self.tide_republish_gen_watch
+            .store(generation, std::sync::atomic::Ordering::Relaxed);
+    }
+
     pub fn query_snapshot(&self) -> LspQuerySnapshotV0 {
         LspQuerySnapshotV0 {
             state: LspShellState {

--- a/rust/crates/omena-lsp-server/src/state.rs
+++ b/rust/crates/omena-lsp-server/src/state.rs
@@ -181,6 +181,17 @@ pub struct LspShellStateSnapshot {
     pub configuration_change_count: usize,
     pub watched_file_event_count: usize,
     pub cached_workspace_resolution_input_count: usize,
+    /// Tide observability (rfcs#111 §11.4): the ledger epoch and the state
+    /// of both settle-gated lanes, so #110-style loop debugging is a debug
+    /// request instead of ad-hoc instrumentation.
+    pub tide_epoch: u64,
+    pub tide_sif_lane_generation: u64,
+    pub tide_sif_lane_in_flight: bool,
+    pub tide_sif_lane_has_demand: bool,
+    pub tide_republish_lane_generation: u64,
+    pub tide_republish_lane_in_flight: bool,
+    pub tide_republish_lane_has_demand: bool,
+    pub tide_starvation_alarm_count: u64,
     pub documents: Vec<LspTextDocumentState>,
     pub workspace_folders: Vec<LspWorkspaceFolderState>,
     pub watched_file_changes: Vec<LspWatchedFileChangeState>,
@@ -491,6 +502,15 @@ impl LspShellState {
                 .resolution
                 .workspace_style_resolution_inputs
                 .len(),
+            tide_epoch: self.tide_ledger.epoch(),
+            tide_sif_lane_generation: self.tide_sif_lane.generation(),
+            tide_sif_lane_in_flight: self.tide_sif_lane.in_flight(),
+            tide_sif_lane_has_demand: self.tide_sif_lane.has_demand(),
+            tide_republish_lane_generation: self.tide_republish_lane.generation(),
+            tide_republish_lane_in_flight: self.tide_republish_lane.in_flight(),
+            tide_republish_lane_has_demand: self.tide_republish_lane.has_demand(),
+            tide_starvation_alarm_count: self.tide_sif_lane.starvation_alarm_count()
+                + self.tide_republish_lane.starvation_alarm_count(),
             documents: {
                 let mut documents = self
                     .documents

--- a/rust/crates/omena-lsp-server/src/state.rs
+++ b/rust/crates/omena-lsp-server/src/state.rs
@@ -311,12 +311,13 @@ pub struct LspShellState {
     pub(crate) external_sif_lock_read_count: usize,
     pub(crate) external_sif_bridge_generation_count: usize,
     pub(crate) external_sif_refresh_deferred: bool,
-    pub(crate) external_sif_refresh_dirty: bool,
-    /// Set when a background index wave admits style documents; consumed by
-    /// the index-quiesce check (`pending == 0`) that schedules ONE external
-    /// SIF refresh for the whole admission burst instead of one per wave.
-    pub(crate) external_sif_refresh_owed_for_admitted_styles: bool,
-    pub(crate) external_sif_refresh_revision: u64,
+    /// Tide kernel (rfcs#111): the epoch ledger with per-input high-water
+    /// marks, and the two settle-gated demand lanes. Trigger sites deposit
+    /// demands; the gates decide when a flush happens. These replace the
+    /// dirty/owed flags and the per-subsystem refresh revision.
+    pub(crate) tide_ledger: crate::tide::TideEpochLedgerV0,
+    pub(crate) tide_sif_lane: crate::tide::TideLaneV0,
+    pub(crate) tide_republish_lane: crate::tide::TideLaneV0,
     pub(crate) workspace_index_revision: u64,
     pub(crate) configuration_change_count: usize,
     /// RFC 0009 Pillar A (rfcs#67, slice A-min): documents are `Arc` entries so a

--- a/rust/crates/omena-lsp-server/src/streaming_ifds_diagnostics.rs
+++ b/rust/crates/omena-lsp-server/src/streaming_ifds_diagnostics.rs
@@ -2,7 +2,30 @@ use omena_query::{
     OmenaQueryCrossFileSummaryV0, OmenaQueryStyleDiagnosticV0, ParserRangeV0,
     summarize_omena_query_unified_cross_file_hypergraph,
 };
-use omena_streaming_ifds::summarize_streaming_ifds_cross_file_reachability_v0;
+use omena_streaming_ifds::{
+    StreamingIFDSCrossFileReachabilityReportV0, StreamingIfdsReachabilityCondensationV0,
+    streaming_ifds_reachability_condensation_v0,
+    summarize_streaming_ifds_cross_file_reachability_v0,
+    summarize_streaming_ifds_cross_file_reachability_with_condensation_v0,
+};
+
+/// Target-INDEPENDENT reachability state shared across a wave (rfcs#111, the
+/// first C1 slice): the unified hypergraph derivation and its SCC
+/// condensation, built once per committed graph instead of once per target.
+#[derive(Debug)]
+pub(crate) struct SharedStreamingReachabilityV0 {
+    condensation: StreamingIfdsReachabilityCondensationV0,
+}
+
+pub(crate) fn shared_streaming_reachability_for_lsp(
+    committed_cross_file_summary: &OmenaQueryCrossFileSummaryV0,
+) -> SharedStreamingReachabilityV0 {
+    let hypergraph =
+        summarize_omena_query_unified_cross_file_hypergraph(committed_cross_file_summary);
+    SharedStreamingReachabilityV0 {
+        condensation: streaming_ifds_reachability_condensation_v0(hypergraph.hyperedges.as_slice()),
+    }
+}
 
 pub(crate) fn summarize_cross_file_streaming_reachability_diagnostics_for_lsp(
     target_style_path: &str,
@@ -14,6 +37,25 @@ pub(crate) fn summarize_cross_file_streaming_reachability_diagnostics_for_lsp(
         target_style_path,
         hypergraph.hyperedges.as_slice(),
     );
+    reachability_report_diagnostics(report)
+}
+
+/// The shared-condensation arm — byte-identical to the per-call arm above
+/// (gated by the parity test in omena-streaming-ifds).
+pub(crate) fn summarize_cross_file_streaming_reachability_diagnostics_for_lsp_shared(
+    target_style_path: &str,
+    shared: &SharedStreamingReachabilityV0,
+) -> Vec<OmenaQueryStyleDiagnosticV0> {
+    let report = summarize_streaming_ifds_cross_file_reachability_with_condensation_v0(
+        target_style_path,
+        &shared.condensation,
+    );
+    reachability_report_diagnostics(report)
+}
+
+fn reachability_report_diagnostics(
+    report: StreamingIFDSCrossFileReachabilityReportV0,
+) -> Vec<OmenaQueryStyleDiagnosticV0> {
     if report.reachable_foreign_paths.is_empty() {
         return Vec::new();
     }

--- a/rust/crates/omena-lsp-server/src/style_diagnostics.rs
+++ b/rust/crates/omena-lsp-server/src/style_diagnostics.rs
@@ -299,6 +299,24 @@ pub(crate) fn finish_style_diagnostics_value(
     workspace_diagnostics_summary: Option<omena_query::OmenaQueryStyleDiagnosticsForFileV0>,
     committed_cross_file_summary: Option<&omena_query::OmenaQueryCrossFileSummaryV0>,
 ) -> Value {
+    finish_style_diagnostics_value_with_shared_reachability(
+        inputs,
+        workspace_diagnostics_summary,
+        committed_cross_file_summary,
+        None,
+    )
+}
+
+/// The wave arm passes a per-wave shared SCC condensation so the streaming
+/// reachability append is a BFS instead of a full graph rebuild per target
+/// (rfcs#111, the first C1 slice); `None` keeps the per-call arm — the two
+/// are byte-identical, gated by the omena-streaming-ifds parity test.
+pub(crate) fn finish_style_diagnostics_value_with_shared_reachability(
+    inputs: &LspStyleDiagnosticsRenderInputsV0<'_>,
+    workspace_diagnostics_summary: Option<omena_query::OmenaQueryStyleDiagnosticsForFileV0>,
+    committed_cross_file_summary: Option<&omena_query::OmenaQueryCrossFileSummaryV0>,
+    shared_reachability: Option<&crate::streaming_ifds_diagnostics::SharedStreamingReachabilityV0>,
+) -> Value {
     let mut diagnostics_summary = workspace_diagnostics_summary.unwrap_or_else(|| {
         summarize_omena_query_style_diagnostics_for_file(
             inputs.document_uri,
@@ -307,12 +325,20 @@ pub(crate) fn finish_style_diagnostics_value(
         )
     });
     if let Some(committed_cross_file_summary) = committed_cross_file_summary {
-        diagnostics_summary.diagnostics.extend(
-            summarize_cross_file_streaming_reachability_diagnostics_for_lsp(
-                inputs.document_uri,
-                committed_cross_file_summary,
-            ),
-        );
+        diagnostics_summary
+            .diagnostics
+            .extend(match shared_reachability {
+                Some(shared) => {
+                    crate::streaming_ifds_diagnostics::summarize_cross_file_streaming_reachability_diagnostics_for_lsp_shared(
+                        inputs.document_uri,
+                        shared,
+                    )
+                }
+                None => summarize_cross_file_streaming_reachability_diagnostics_for_lsp(
+                    inputs.document_uri,
+                    committed_cross_file_summary,
+                ),
+            });
     }
     if inputs.deep_analysis {
         diagnostics_summary

--- a/rust/crates/omena-lsp-server/src/tests.rs
+++ b/rust/crates/omena-lsp-server/src/tests.rs
@@ -83,6 +83,8 @@ mod style_context;
 mod style_indexing;
 #[path = "tests/svelte_component.rs"]
 mod svelte_component;
+#[path = "tests/tide_kernel.rs"]
+mod tide_kernel;
 #[path = "tests/vue_sfc.rs"]
 mod vue_sfc;
 #[path = "tests/workspace_folders.rs"]

--- a/rust/crates/omena-lsp-server/src/tests.rs
+++ b/rust/crates/omena-lsp-server/src/tests.rs
@@ -85,6 +85,12 @@ mod style_indexing;
 mod svelte_component;
 #[path = "tests/tide_kernel.rs"]
 mod tide_kernel;
+#[cfg(all(
+    feature = "salsa-style-diagnostics",
+    feature = "parallel-style-diagnostics"
+))]
+#[path = "tests/tide_republish_executor.rs"]
+mod tide_republish_executor;
 #[path = "tests/vue_sfc.rs"]
 mod vue_sfc;
 #[path = "tests/workspace_folders.rs"]

--- a/rust/crates/omena-lsp-server/src/tests/path_identity_perf.rs
+++ b/rust/crates/omena-lsp-server/src/tests/path_identity_perf.rs
@@ -1,0 +1,100 @@
+//! Path-identity perf gates (RFC: LSP main-loop O(N^2) path-identity hot path).
+//!
+//! The document store derives file identity through `protocol::normalize_path` on
+//! every access (key derivation) and, on a lookup miss, once per existing key in
+//! a linear `file_uri_equivalent` scan; `normalize_path` performs an
+//! `fs::canonicalize` syscall. During workspace indexing this is an O(N^2) syscall
+//! storm that starves the main loop. The fix is canonicalize-once (memoize the
+//! chokepoint). These gates assert the canonicalize-once invariant directly at
+//! `normalize_path`: repeated identity of the same existing path performs zero
+//! syscalls, and touching N distinct existing paths over M waves performs at most
+//! N syscalls (once per distinct path), not N*M. Both are RED on the pre-fix code
+//! (one syscall per call) and GREEN after the memo.
+
+use super::TestResult;
+use crate::protocol::{
+    canonicalize_syscall_count, normalize_path, reset_canonicalize_syscall_count,
+};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static UNIQUE: AtomicUsize = AtomicUsize::new(0);
+
+fn fresh_dir(tag: &str) -> std::io::Result<PathBuf> {
+    let unique = UNIQUE.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "omena_pathid_{}_{}_{}",
+        tag,
+        std::process::id(),
+        unique
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn make_scss(dir: &Path, name: &str) -> std::io::Result<PathBuf> {
+    let path = dir.join(name);
+    std::fs::write(&path, ".x { color: red; }\n")?;
+    Ok(path)
+}
+
+#[test]
+fn normalize_path_repeated_identity_is_zero_syscall() -> TestResult {
+    let dir = fresh_dir("repeat")?;
+    let path = make_scss(&dir, "a.module.scss")?;
+
+    // Prime: the first canonicalize of an existing path is the unavoidable
+    // one-time cost.
+    let primed = normalize_path(path.clone());
+
+    reset_canonicalize_syscall_count();
+    const REPEATS: usize = 64;
+    for _ in 0..REPEATS {
+        let again = normalize_path(path.clone());
+        assert_eq!(again, primed, "canonical form must be stable across repeats");
+    }
+
+    let syscalls = canonicalize_syscall_count();
+    assert_eq!(
+        syscalls, 0,
+        "repeating identity of the same existing path must perform ZERO fs::canonicalize \
+         syscalls (canonicalize-once memo); got {syscalls} over {REPEATS} repeats"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}
+
+#[test]
+fn normalize_path_canonicalizes_each_distinct_path_at_most_once() -> TestResult {
+    let dir = fresh_dir("scaling")?;
+    const N: usize = 64;
+    const PASSES: usize = 8;
+    let mut paths: Vec<PathBuf> = Vec::with_capacity(N);
+    for i in 0..N {
+        paths.push(make_scss(&dir, &format!("m{i}.module.scss"))?);
+    }
+
+    // Mirror the document-store hot path: each of PASSES waves re-derives identity
+    // for every path (the per-batch reinsert + linear scan). The storm is
+    // O(N * PASSES) syscalls today; canonicalize-once makes it O(N).
+    reset_canonicalize_syscall_count();
+    for _ in 0..PASSES {
+        for path in &paths {
+            let _ = normalize_path(path.clone());
+        }
+    }
+
+    let syscalls = canonicalize_syscall_count();
+    assert!(
+        syscalls <= N,
+        "indexing {N} distinct existing paths over {PASSES} waves must perform at most \
+         one fs::canonicalize per distinct path (<= {N}); got {syscalls} \
+         (pre-fix this is ~{} = N*PASSES)",
+        N * PASSES
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}

--- a/rust/crates/omena-lsp-server/src/tests/tide_kernel.rs
+++ b/rust/crates/omena-lsp-server/src/tests/tide_kernel.rs
@@ -1,0 +1,261 @@
+//! M0 property harness for the Tide kernel (rfcs#111 §12): synthetic event
+//! streams drive the lane/ledger and machine-check the invariants I1, I5,
+//! and the footprint-validity rule against an independent model. The oracle
+//! exists before the wiring it gates.
+
+use crate::tide::{
+    TideDemandV0, TideEpochLedgerV0, TideFootprintV0, TideGateInputsV0, TideInputKindV0,
+    TideLaneConfigV0, TideLaneV0, tide_may_publish,
+};
+use std::collections::BTreeSet;
+
+/// Deterministic xorshift64 — no new dependencies, reproducible failures.
+struct XorShift64(u64);
+
+impl XorShift64 {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn below(&mut self, bound: u64) -> u64 {
+        self.next() % bound
+    }
+}
+
+const SIF_FOOTPRINT: TideFootprintV0 = TideFootprintV0::of(&[
+    TideInputKindV0::DocumentSet,
+    TideInputKindV0::LockfileFingerprint,
+    TideInputKindV0::PackageManifest,
+    TideInputKindV0::ResolutionSettings,
+]);
+
+#[test]
+fn footprint_validity_ignores_unrelated_input_kinds() {
+    // rfcs#111 §9.3: a keystroke cannot kill an in-flight SIF job.
+    let mut ledger = TideEpochLedgerV0::default();
+    ledger.advance(&[TideInputKindV0::DocumentSet]);
+    let stamp = ledger.stamp(SIF_FOOTPRINT);
+
+    ledger.advance(&[TideInputKindV0::DocumentText]);
+    assert!(
+        ledger.is_current(&stamp),
+        "a DocumentText advance must not stale a job that never reads it"
+    );
+
+    ledger.advance(&[TideInputKindV0::DocumentSet]);
+    assert!(
+        !ledger.is_current(&stamp),
+        "a footprint-member advance must stale the stamp"
+    );
+}
+
+#[test]
+fn footprint_validity_matches_model_under_random_advances() {
+    for seed in 1..=20u64 {
+        let mut rng = XorShift64(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        let mut ledger = TideEpochLedgerV0::default();
+        let mut stamp = ledger.stamp(SIF_FOOTPRINT);
+        let mut model_stale = false;
+        for _ in 0..2_000 {
+            let kind = TideInputKindV0::ALL[rng.below(7) as usize];
+            ledger.advance(&[kind]);
+            if SIF_FOOTPRINT.contains(kind) {
+                model_stale = true;
+            }
+            assert_eq!(
+                ledger.is_current(&stamp),
+                !model_stale,
+                "validity diverged from the model after advancing {kind:?}"
+            );
+            if rng.below(4) == 0 {
+                stamp = ledger.stamp(SIF_FOOTPRINT);
+                model_stale = false;
+            }
+        }
+    }
+}
+
+#[test]
+fn lane_invariants_hold_under_random_event_streams() {
+    let config = TideLaneConfigV0 {
+        aging_bound_ticks: 10,
+    };
+    for seed in 1..=50u64 {
+        let mut rng = XorShift64(seed.wrapping_mul(0x2545_F491_4F6C_DD1D));
+        let mut lane = TideLaneV0::default();
+        let mut model_demands: BTreeSet<TideDemandV0> = BTreeSet::new();
+        let mut model_in_flight = false;
+        for tick in 0..3_000u64 {
+            match rng.below(6) {
+                0 | 1 => {
+                    let demand = if rng.below(2) == 0 {
+                        TideDemandV0::SifRefresh
+                    } else {
+                        TideDemandV0::WorkspaceRepublish
+                    };
+                    lane.deposit(demand.clone(), tick);
+                    model_demands.insert(demand);
+                }
+                2 | 3 => {
+                    let inputs = TideGateInputsV0 {
+                        frontier_passed: rng.below(2) == 0,
+                        idle: rng.below(2) == 0,
+                    };
+                    let alarms_before = lane.starvation_alarm_count();
+                    match lane.try_flush(inputs, tick, &config) {
+                        Some(flush) => {
+                            // I5: aging never satisfies the correctness layer.
+                            assert!(inputs.frontier_passed, "flush behind a closed frontier");
+                            // I1: one in-flight tide per lane; never from empty.
+                            assert!(!model_in_flight, "second concurrent tide");
+                            assert!(!model_demands.is_empty(), "flush from an empty lane");
+                            let drained: Vec<_> = model_demands.iter().cloned().collect();
+                            assert_eq!(flush.demands, drained, "flush must drain everything");
+                            assert_eq!(flush.generation, lane.generation());
+                            model_demands.clear();
+                            model_in_flight = true;
+                        }
+                        None => {
+                            if lane.starvation_alarm_count() > alarms_before {
+                                assert!(
+                                    !inputs.frontier_passed,
+                                    "starvation alarm outside a closed frontier"
+                                );
+                            }
+                        }
+                    }
+                }
+                4 => {
+                    // Completion, sometimes with a deliberately stale generation.
+                    let generation = if rng.below(4) == 0 {
+                        lane.generation().saturating_sub(1)
+                    } else {
+                        lane.generation()
+                    };
+                    let matches_current = generation == lane.generation();
+                    lane.tide_completed(generation);
+                    if matches_current && model_in_flight {
+                        model_in_flight = false;
+                    }
+                }
+                _ => {
+                    let generation_before = lane.generation();
+                    let generation_after = lane.reopen_window();
+                    if model_in_flight {
+                        // rfcs#111 §9.4: the running tide is disowned.
+                        assert_eq!(generation_after, generation_before + 1);
+                        model_in_flight = false;
+                    } else {
+                        assert_eq!(generation_after, generation_before);
+                    }
+                }
+            }
+            assert_eq!(
+                lane.in_flight(),
+                model_in_flight,
+                "in-flight model diverged"
+            );
+        }
+    }
+}
+
+#[test]
+fn aging_overrides_courtesy_but_never_correctness() {
+    let config = TideLaneConfigV0 {
+        aging_bound_ticks: 10,
+    };
+    let mut lane = TideLaneV0::default();
+    lane.deposit(TideDemandV0::WorkspaceRepublish, 0);
+
+    // Aged demand behind a CLOSED frontier: no flush, one alarm per window.
+    let closed = TideGateInputsV0 {
+        frontier_passed: false,
+        idle: true,
+    };
+    assert!(lane.try_flush(closed, 15, &config).is_none());
+    assert_eq!(lane.starvation_alarm_count(), 1);
+    assert!(lane.try_flush(closed, 16, &config).is_none());
+    assert_eq!(
+        lane.starvation_alarm_count(),
+        1,
+        "alarm fires once per accumulation window"
+    );
+
+    // Same aged demand, frontier OPEN but not idle: aging overrides courtesy.
+    let open_busy = TideGateInputsV0 {
+        frontier_passed: true,
+        idle: false,
+    };
+    let flush = lane
+        .try_flush(open_busy, 17, &config)
+        .expect("aged demand must flush once the frontier passes");
+    assert_eq!(flush.demands, vec![TideDemandV0::WorkspaceRepublish]);
+
+    // A fresh demand while busy: courtesy holds it back until idle or aged.
+    lane.tide_completed(flush.generation);
+    lane.deposit(TideDemandV0::WorkspaceRepublish, 20);
+    assert!(lane.try_flush(open_busy, 21, &config).is_none());
+    let open_idle = TideGateInputsV0 {
+        frontier_passed: true,
+        idle: true,
+    };
+    assert!(lane.try_flush(open_idle, 22, &config).is_some());
+}
+
+#[test]
+fn one_flush_per_window_and_deposit_idempotence() {
+    let config = TideLaneConfigV0 {
+        aging_bound_ticks: 10,
+    };
+    let open_idle = TideGateInputsV0 {
+        frontier_passed: true,
+        idle: true,
+    };
+    let mut lane = TideLaneV0::default();
+    assert!(lane.deposit(TideDemandV0::SifRefresh, 0));
+    assert!(
+        !lane.deposit(TideDemandV0::SifRefresh, 1),
+        "deposits are idempotent"
+    );
+
+    let flush = lane.try_flush(open_idle, 2, &config).expect("gate open");
+    assert_eq!(flush.demands, vec![TideDemandV0::SifRefresh]);
+    // I1: no second flush while the tide is in flight, even with demand.
+    lane.deposit(TideDemandV0::SifRefresh, 3);
+    assert!(lane.try_flush(open_idle, 4, &config).is_none());
+    lane.tide_completed(flush.generation);
+    assert!(lane.try_flush(open_idle, 5, &config).is_some());
+    // Empty lane never flushes.
+    assert!(lane.try_flush(open_idle, 6, &config).is_none());
+}
+
+#[test]
+fn publication_supersession_order_key_is_epoch_then_tier() {
+    // rfcs#111 §8.4 / I6.
+    assert!(tide_may_publish(None, (1, 0)));
+    assert!(
+        tide_may_publish(Some((1, 0)), (1, 1)),
+        "refined after baseline"
+    );
+    assert!(
+        !tide_may_publish(Some((1, 1)), (1, 0)),
+        "delayed baseline must lose"
+    );
+    assert!(
+        !tide_may_publish(Some((2, 0)), (1, 1)),
+        "older epoch must lose"
+    );
+    assert!(
+        tide_may_publish(Some((1, 1)), (2, 0)),
+        "new epoch supersedes any tier"
+    );
+    assert!(
+        tide_may_publish(Some((1, 1)), (1, 1)),
+        "ties are idempotent republish"
+    );
+}

--- a/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
+++ b/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
@@ -75,11 +75,12 @@ fn republish_tide_round_trip_covers_the_corpus() {
         "one in-flight tide per lane"
     );
 
-    let mut chunks = Vec::new();
-    collect_tide_workspace_republish_streaming(job, &mut |result| {
-        chunks.push(result);
+    let chunks = std::sync::Mutex::new(Vec::new());
+    collect_tide_workspace_republish_streaming(job, &|result| {
+        chunks.lock().unwrap().push(result);
         true
     });
+    let chunks = chunks.into_inner().unwrap();
     assert!(
         chunks.last().is_some_and(|chunk| chunk.final_chunk),
         "the stream must terminate with a final chunk"
@@ -135,11 +136,12 @@ fn disowned_republish_tide_drops_leftovers_and_rearms() {
     state.tide_reopen_republish_window();
     assert!(state.tide_republish_lane_generation() > generation);
 
-    let mut chunks = Vec::new();
-    collect_tide_workspace_republish_streaming(job, &mut |result| {
-        chunks.push(result);
+    let chunks = std::sync::Mutex::new(Vec::new());
+    collect_tide_workspace_republish_streaming(job, &|result| {
+        chunks.lock().unwrap().push(result);
         true
     });
+    let chunks = chunks.into_inner().unwrap();
     assert!(
         chunks.iter().all(|chunk| chunk.items.is_empty()),
         "an aborted wave covers nothing"

--- a/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
+++ b/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
@@ -5,7 +5,7 @@
 use super::handle_lsp_message;
 use crate::tide::TideDemandV0;
 use crate::{
-    LspShellState, apply_tide_workspace_republish_item, collect_tide_workspace_republish,
+    LspShellState, apply_tide_workspace_republish_item, collect_tide_workspace_republish_streaming,
     complete_tide_workspace_republish, enable_deferred_external_sif_refresh,
     prepare_tide_workspace_republish_job,
 };
@@ -75,22 +75,35 @@ fn republish_tide_round_trip_covers_the_corpus() {
         "one in-flight tide per lane"
     );
 
-    let result = collect_tide_workspace_republish(job);
-    assert_eq!(result.generation, generation);
+    let mut chunks = Vec::new();
+    collect_tide_workspace_republish_streaming(job, &mut |result| {
+        chunks.push(result);
+        true
+    });
+    assert!(
+        chunks.last().is_some_and(|chunk| chunk.final_chunk),
+        "the stream must terminate with a final chunk"
+    );
+    let mut items = Vec::new();
+    let mut uncovered = Vec::new();
+    for chunk in chunks {
+        assert_eq!(chunk.generation, generation);
+        items.extend(chunk.items);
+        uncovered.extend(chunk.uncovered_uris);
+    }
     assert_eq!(
-        result.items.len() + result.uncovered_uris.len(),
+        items.len() + uncovered.len(),
         2,
         "every corpus target is either covered or reported uncovered"
     );
 
     let mut published = 0usize;
-    for item in result.items {
+    for item in items {
         let outputs = apply_tide_workspace_republish_item(&mut state, item);
         assert!(!outputs.is_empty(), "an applied item must publish");
         published += 1;
     }
-    let effects =
-        complete_tide_workspace_republish(&mut state, generation, result.uncovered_uris.clone());
+    let effects = complete_tide_workspace_republish(&mut state, generation, uncovered.clone());
     assert!(
         published > 0 || !effects.deferred_diagnostics.is_empty() || !effects.outputs.is_empty(),
         "the tide must reach every target through the wave or the fallback arm"
@@ -122,12 +135,21 @@ fn disowned_republish_tide_drops_leftovers_and_rearms() {
     state.tide_reopen_republish_window();
     assert!(state.tide_republish_lane_generation() > generation);
 
-    let result = collect_tide_workspace_republish(job);
+    let mut chunks = Vec::new();
+    collect_tide_workspace_republish_streaming(job, &mut |result| {
+        chunks.push(result);
+        true
+    });
     assert!(
-        result.items.is_empty(),
-        "an aborted wave covers nothing: every target is uncovered"
+        chunks.iter().all(|chunk| chunk.items.is_empty()),
+        "an aborted wave covers nothing"
     );
-    let effects = complete_tide_workspace_republish(&mut state, generation, result.uncovered_uris);
+    assert!(chunks.last().is_some_and(|chunk| chunk.final_chunk));
+    let uncovered: Vec<String> = chunks
+        .into_iter()
+        .flat_map(|chunk| chunk.uncovered_uris)
+        .collect();
+    let effects = complete_tide_workspace_republish(&mut state, generation, uncovered);
     assert!(
         effects.outputs.is_empty() && effects.deferred_diagnostics.is_empty(),
         "a disowned tide must not schedule fallback work"

--- a/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
+++ b/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
@@ -1,0 +1,136 @@
+//! M3 executor round-trip tests (rfcs#111 §8.5): prepare → collect → apply →
+//! complete against a real two-document corpus, plus the disowned-tide path
+//! where a window reopen drops the pending applies.
+
+use super::handle_lsp_message;
+use crate::tide::TideDemandV0;
+use crate::{
+    LspShellState, apply_tide_workspace_republish_item, collect_tide_workspace_republish,
+    complete_tide_workspace_republish, enable_deferred_external_sif_refresh,
+    prepare_tide_workspace_republish_job,
+};
+use serde_json::json;
+
+fn open_style_document(state: &mut LspShellState, uri: &str, text: &str) {
+    handle_lsp_message(
+        state,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "scss",
+                    "version": 1,
+                    "text": text,
+                },
+            },
+        }),
+    );
+}
+
+fn republish_fixture_state() -> LspShellState {
+    let mut state = LspShellState::default();
+    enable_deferred_external_sif_refresh(&mut state);
+    open_style_document(
+        &mut state,
+        "file:///workspace/src/Alpha.module.scss",
+        ".alpha { color: red; }",
+    );
+    open_style_document(
+        &mut state,
+        "file:///workspace/src/Beta.module.scss",
+        ".beta { color: blue; }",
+    );
+    state
+}
+
+#[test]
+fn republish_tide_round_trip_covers_the_corpus() {
+    let mut state = republish_fixture_state();
+    let tick = 0;
+    state
+        .tide_republish_lane
+        .deposit(TideDemandV0::WorkspaceRepublish, tick);
+
+    // The SIF lane holds startup demand (enable_deferred deposits), which
+    // closes the republish frontier: no flush yet.
+    assert!(
+        prepare_tide_workspace_republish_job(&mut state, true).is_none(),
+        "republish must wait for the SIF lane to settle"
+    );
+
+    // Settle the SIF lane the way the loop does: flush its demand into a job
+    // and apply the (unchanged) result.
+    let sif_job = crate::prepare_deferred_external_sif_refresh_job(&mut state)
+        .expect("startup SIF demand must flush");
+    let sif_result = crate::collect_deferred_external_sif_refresh(sif_job);
+    crate::apply_deferred_external_sif_refresh_result(&mut state, sif_result);
+
+    let job = prepare_tide_workspace_republish_job(&mut state, true)
+        .expect("settled frontier + idle courtesy must flush");
+    let generation = job.generation;
+    assert!(
+        prepare_tide_workspace_republish_job(&mut state, true).is_none(),
+        "one in-flight tide per lane"
+    );
+
+    let result = collect_tide_workspace_republish(job);
+    assert_eq!(result.generation, generation);
+    assert_eq!(
+        result.items.len() + result.uncovered_uris.len(),
+        2,
+        "every corpus target is either covered or reported uncovered"
+    );
+
+    let mut published = 0usize;
+    for item in result.items {
+        let outputs = apply_tide_workspace_republish_item(&mut state, item);
+        assert!(!outputs.is_empty(), "an applied item must publish");
+        published += 1;
+    }
+    let effects =
+        complete_tide_workspace_republish(&mut state, generation, result.uncovered_uris.clone());
+    assert!(
+        published > 0 || !effects.deferred_diagnostics.is_empty() || !effects.outputs.is_empty(),
+        "the tide must reach every target through the wave or the fallback arm"
+    );
+    assert!(
+        !state.tide_republish_lane.in_flight(),
+        "completion re-arms the lane"
+    );
+}
+
+#[test]
+fn disowned_republish_tide_drops_leftovers_and_rearms() {
+    let mut state = republish_fixture_state();
+    let sif_job = crate::prepare_deferred_external_sif_refresh_job(&mut state)
+        .expect("startup SIF demand must flush");
+    let sif_result = crate::collect_deferred_external_sif_refresh(sif_job);
+    crate::apply_deferred_external_sif_refresh_result(&mut state, sif_result);
+
+    state
+        .tide_republish_lane
+        .deposit(TideDemandV0::WorkspaceRepublish, 0);
+    let job = prepare_tide_workspace_republish_job(&mut state, true).expect("gate open");
+    let generation = job.generation;
+
+    // The settle window reopens while the tide is in flight: the generation
+    // watch moves, the wave aborts at item boundaries, and completion with
+    // the stale generation must drop leftovers without touching the lane's
+    // NEW generation.
+    state.tide_reopen_republish_window();
+    assert!(state.tide_republish_lane_generation() > generation);
+
+    let result = collect_tide_workspace_republish(job);
+    assert!(
+        result.items.is_empty(),
+        "an aborted wave covers nothing: every target is uncovered"
+    );
+    let effects = complete_tide_workspace_republish(&mut state, generation, result.uncovered_uris);
+    assert!(
+        effects.outputs.is_empty() && effects.deferred_diagnostics.is_empty(),
+        "a disowned tide must not schedule fallback work"
+    );
+    assert!(!state.tide_republish_lane.in_flight());
+}

--- a/rust/crates/omena-lsp-server/src/tests/workspace_indexing.rs
+++ b/rust/crates/omena-lsp-server/src/tests/workspace_indexing.rs
@@ -1960,14 +1960,18 @@ fn workspace_index_follow_up_wave_count_stays_within_baseline() -> TestResult {
         pending_file_count: 0,
         exhausted: false,
     };
-    let revision_before = state.external_sif_refresh_revision;
     assert!(apply_background_workspace_index_result(&mut state, result));
-    let refresh_revision_delta = state
-        .external_sif_refresh_revision
-        .saturating_sub(revision_before);
     let job = prepare_deferred_external_sif_refresh_job(&mut state).ok_or_else(|| {
         std::io::Error::other("workspace-index result did not schedule external SIF refresh")
     })?;
+    // One settle window admits exactly one refresh tide: the lane is drained
+    // and in flight, so a second prepare must be a no-op (rfcs#111 I1).
+    let refresh_revision_delta: u64 =
+        if prepare_deferred_external_sif_refresh_job(&mut state).is_some() {
+            2
+        } else {
+            1
+        };
     let result = collect_deferred_external_sif_refresh(job);
     let effects =
         apply_external_sif_refresh_result_follow_up_diagnostics_effects(&mut state, result);

--- a/rust/crates/omena-lsp-server/src/tide/demand.rs
+++ b/rust/crates/omena-lsp-server/src/tide/demand.rs
@@ -1,0 +1,141 @@
+//! Demand lanes and settle gates (rfcs#111 §4.1, §9.6).
+//!
+//! Trigger sites deposit demands — idempotently, into a set — and nothing
+//! else; whether, when, and how often work executes is decided here, once,
+//! at gate evaluation. The gate has two layers with strictly different
+//! authority (rfcs#111 §7 I5):
+//!
+//! - the CORRECTNESS layer — frontier passage — is never overridable;
+//! - the COURTESY layer — idleness — may be overridden by aging.
+//!
+//! If upstream genuinely never settles, not flushing is correct, and the
+//! lane records a starvation alarm instead of forcing a flush.
+
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TideDemandV0 {
+    /// Full-workspace external SIF re-resolution.
+    SifRefresh,
+    /// Full-workspace diagnostics republish (the post-SIF follow-up).
+    WorkspaceRepublish,
+}
+
+/// Per-evaluation gate inputs, fed by the shell. The kernel never reads
+/// clocks or channels itself.
+#[derive(Debug, Clone, Copy)]
+pub struct TideGateInputsV0 {
+    /// Correctness layer: the upstream frontier for this lane has passed.
+    pub frontier_passed: bool,
+    /// Courtesy layer: no interactive work is pending.
+    pub idle: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TideLaneConfigV0 {
+    /// Courtesy aging bound, in shell ticks. A demand older than this stops
+    /// waiting for idleness — but never for the frontier.
+    pub aging_bound_ticks: u64,
+}
+
+/// One gated flush: the demands drained from the lane, stamped with the
+/// lane generation that executors re-check at item boundaries.
+#[derive(Debug, PartialEq, Eq)]
+pub struct TideFlushV0 {
+    pub generation: u64,
+    pub demands: Vec<TideDemandV0>,
+}
+
+#[derive(Debug, Default)]
+pub struct TideLaneV0 {
+    demands: BTreeSet<TideDemandV0>,
+    generation: u64,
+    in_flight: bool,
+    oldest_deposit_tick: Option<u64>,
+    starvation_alarmed: bool,
+    starvation_alarm_count: u64,
+}
+
+impl TideLaneV0 {
+    /// Idempotent deposit; returns whether the demand was newly inserted.
+    pub fn deposit(&mut self, demand: TideDemandV0, now_tick: u64) -> bool {
+        if self.oldest_deposit_tick.is_none() {
+            self.oldest_deposit_tick = Some(now_tick);
+        }
+        self.demands.insert(demand)
+    }
+
+    pub fn has_demand(&self) -> bool {
+        !self.demands.is_empty()
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn in_flight(&self) -> bool {
+        self.in_flight
+    }
+
+    pub fn starvation_alarm_count(&self) -> u64 {
+        self.starvation_alarm_count
+    }
+
+    /// Gate evaluation. Flushes at most one tide per settle window: while a
+    /// tide is in flight or the lane is empty, this is a no-op regardless of
+    /// gate inputs (I1). Aging can satisfy the courtesy layer, never the
+    /// correctness layer; an aged demand behind a closed frontier raises the
+    /// starvation alarm once per accumulation window (I5).
+    pub fn try_flush(
+        &mut self,
+        inputs: TideGateInputsV0,
+        now_tick: u64,
+        config: &TideLaneConfigV0,
+    ) -> Option<TideFlushV0> {
+        if self.in_flight || self.demands.is_empty() {
+            return None;
+        }
+        let aged = self
+            .oldest_deposit_tick
+            .is_some_and(|oldest| now_tick.saturating_sub(oldest) >= config.aging_bound_ticks);
+        if !inputs.frontier_passed {
+            if aged && !self.starvation_alarmed {
+                self.starvation_alarmed = true;
+                self.starvation_alarm_count = self.starvation_alarm_count.saturating_add(1);
+            }
+            return None;
+        }
+        if !inputs.idle && !aged {
+            return None;
+        }
+        self.generation = self.generation.saturating_add(1);
+        self.in_flight = true;
+        self.oldest_deposit_tick = None;
+        self.starvation_alarmed = false;
+        Some(TideFlushV0 {
+            generation: self.generation,
+            demands: std::mem::take(&mut self.demands).into_iter().collect(),
+        })
+    }
+
+    /// Upstream input relevant to this lane changed while a tide was in
+    /// flight: the settle window reopens. The running tide is disowned — its
+    /// generation no longer matches, so the executor aborts at the next item
+    /// boundary and its remaining publishes lose supersession (rfcs#111
+    /// §9.4). Returns the new generation for executors' gen-watch.
+    pub fn reopen_window(&mut self) -> u64 {
+        if self.in_flight {
+            self.generation = self.generation.saturating_add(1);
+            self.in_flight = false;
+        }
+        self.generation
+    }
+
+    /// Executor completion for `generation`. Stale completions — a tide that
+    /// was disowned by `reopen_window` — are ignored.
+    pub fn tide_completed(&mut self, generation: u64) {
+        if generation == self.generation {
+            self.in_flight = false;
+        }
+    }
+}

--- a/rust/crates/omena-lsp-server/src/tide/ledger.rs
+++ b/rust/crates/omena-lsp-server/src/tide/ledger.rs
@@ -1,0 +1,116 @@
+//! The epoch ledger (rfcs#111 §4.1, §8.2): one monotone clock plus a
+//! high-water mark per semantic input kind. Jobs carry a footprint-restricted
+//! stamp; validity compares ONLY the marks inside the footprint, so an input
+//! mutation that a derivation never reads cannot stale its in-flight job
+//! (the review BLOCKER: an unfootprinted global clock would discard more
+//! in-flight work than the per-subsystem counters it replaces).
+
+/// The semantic-input taxonomy. Every state mutation the scheduler cares
+/// about advances the ledger under one or more of these kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum TideInputKindV0 {
+    /// didOpen / didChange document text.
+    DocumentText = 0,
+    /// Corpus membership: background-scan admits AND document-event foreign
+    /// admits (the second producer the frontier must see — rfcs#111 §4.2).
+    DocumentSet = 1,
+    /// Lockfile content identity. A fingerprinted source node: watched-file
+    /// events over lockfiles advance this mark, so the SIF job's execution-
+    /// time read is covered by an input instead of being out-of-band.
+    LockfileFingerprint = 2,
+    PackageManifest = 3,
+    ResolutionSettings = 4,
+    /// Diagnostics severity / deep-analysis settings. Wiring this kind is
+    /// the structural fix for the config-staleness bug (rfcs#111 §2).
+    DiagnosticSettings = 5,
+    WorkspaceFolders = 6,
+}
+
+pub const TIDE_INPUT_KIND_COUNT: usize = 7;
+
+impl TideInputKindV0 {
+    pub const ALL: [TideInputKindV0; TIDE_INPUT_KIND_COUNT] = [
+        TideInputKindV0::DocumentText,
+        TideInputKindV0::DocumentSet,
+        TideInputKindV0::LockfileFingerprint,
+        TideInputKindV0::PackageManifest,
+        TideInputKindV0::ResolutionSettings,
+        TideInputKindV0::DiagnosticSettings,
+        TideInputKindV0::WorkspaceFolders,
+    ];
+}
+
+/// A declared input set, constant per derivation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TideFootprintV0(u8);
+
+impl TideFootprintV0 {
+    pub const fn of(kinds: &[TideInputKindV0]) -> Self {
+        let mut bits = 0u8;
+        let mut index = 0;
+        while index < kinds.len() {
+            bits |= 1 << (kinds[index] as u8);
+            index += 1;
+        }
+        Self(bits)
+    }
+
+    pub const fn contains(&self, kind: TideInputKindV0) -> bool {
+        self.0 & (1 << (kind as u8)) != 0
+    }
+}
+
+/// The marks a job read at dispatch time, restricted (logically) to its
+/// footprint. The full array is carried for simplicity; comparisons only
+/// ever consult footprint members.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TideFootprintStampV0 {
+    pub footprint: TideFootprintV0,
+    pub epoch: u64,
+    marks: [u64; TIDE_INPUT_KIND_COUNT],
+}
+
+#[derive(Debug, Default)]
+pub struct TideEpochLedgerV0 {
+    epoch: u64,
+    marks: [u64; TIDE_INPUT_KIND_COUNT],
+}
+
+impl TideEpochLedgerV0 {
+    /// One state mutation: the epoch advances once and stamps the mark of
+    /// every kind the mutation touched.
+    pub fn advance(&mut self, kinds: &[TideInputKindV0]) -> u64 {
+        self.epoch = self.epoch.saturating_add(1);
+        for kind in kinds {
+            self.marks[*kind as usize] = self.epoch;
+        }
+        self.epoch
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    pub fn mark(&self, kind: TideInputKindV0) -> u64 {
+        self.marks[kind as usize]
+    }
+
+    pub fn stamp(&self, footprint: TideFootprintV0) -> TideFootprintStampV0 {
+        TideFootprintStampV0 {
+            footprint,
+            epoch: self.epoch,
+            marks: self.marks,
+        }
+    }
+
+    /// Footprint-scoped validity: current iff no input kind INSIDE the
+    /// footprint advanced past the stamp. Mutations of unrelated kinds are
+    /// invisible here by construction (rfcs#111 §9.3).
+    pub fn is_current(&self, stamp: &TideFootprintStampV0) -> bool {
+        TideInputKindV0::ALL.iter().all(|kind| {
+            !stamp.footprint.contains(*kind)
+                || self.marks[*kind as usize] == stamp.marks[*kind as usize]
+        })
+    }
+}

--- a/rust/crates/omena-lsp-server/src/tide/mod.rs
+++ b/rust/crates/omena-lsp-server/src/tide/mod.rs
@@ -7,9 +7,6 @@
 //! routes flushes out to executors; that split is what makes the invariants
 //! property-testable on synthetic event streams (rfcs#111 §12 M0).
 
-// The M2 wiring commit consumes every item below and removes this attribute.
-#![allow(dead_code)]
-
 pub mod demand;
 pub mod ledger;
 

--- a/rust/crates/omena-lsp-server/src/tide/mod.rs
+++ b/rust/crates/omena-lsp-server/src/tide/mod.rs
@@ -1,0 +1,24 @@
+//! Tide scheduling kernel (rfcs#111): an epoch ledger with per-input
+//! high-water marks, footprint-scoped job validity, and idempotent demand
+//! lanes flushed through settle gates.
+//!
+//! The kernel is pure data — no threads, no channels, no clocks. The shell
+//! feeds events in (`advance`, `deposit`, gate inputs per evaluation) and
+//! routes flushes out to executors; that split is what makes the invariants
+//! property-testable on synthetic event streams (rfcs#111 §12 M0).
+
+// The M2 wiring commit consumes every item below and removes this attribute.
+#![allow(dead_code)]
+
+pub mod demand;
+pub mod ledger;
+
+pub use demand::{TideDemandV0, TideFlushV0, TideGateInputsV0, TideLaneConfigV0, TideLaneV0};
+pub use ledger::{TideEpochLedgerV0, TideFootprintStampV0, TideFootprintV0, TideInputKindV0};
+
+/// Publication supersession rule (rfcs#111 §8.4): per-key last-writer-wins on
+/// the lexicographic order key `(epoch, tier_rank)`, so a delayed baseline
+/// can never overwrite its refined sibling and ties stay idempotent.
+pub fn tide_may_publish(last_published: Option<(u64, u8)>, next: (u64, u8)) -> bool {
+    last_published.is_none_or(|last| next >= last)
+}

--- a/rust/crates/omena-lsp-server/src/tide_republish.rs
+++ b/rust/crates/omena-lsp-server/src/tide_republish.rs
@@ -52,13 +52,6 @@ pub struct TideWorkspaceRepublishResultV0 {
     pub final_chunk: bool,
 }
 
-/// Streaming chunk size (rfcs#111 §8.5): the wave runs per chunk against the
-/// SAME snapshot — the memo host diff-syncs to a no-op after the first chunk
-/// — so covered values reach the editor as the tide progresses instead of at
-/// the end. Open documents are ordered first (see prepare), so the files the
-/// user is looking at converge within the first chunks.
-pub const TIDE_REPUBLISH_STREAM_CHUNK: usize = 8;
-
 /// Gate evaluation + snapshot capture, on the loop. `idle` is the courtesy
 /// input (no recent client message); aging overrides it after
 /// [`TIDE_REPUBLISH_LANE_CONFIG`]'s bound, the frontier never.
@@ -116,68 +109,65 @@ pub fn prepare_tide_workspace_republish_job(
     })
 }
 
-/// Worker-side compute, streaming (rfcs#111 §8.5): the shared-graph parallel
-/// wave runs per chunk against the SAME snapshot — the first chunk pays the
-/// memo-host sync, later chunks diff-sync to a no-op — and each chunk's
-/// covered values are emitted immediately. `emit` returns false when the
-/// receiver is gone; the generation watch is checked between chunks AND at
-/// item boundaries inside the wave.
+/// Worker-side compute, streaming (rfcs#111 §8.5): ONE shared-graph parallel
+/// wave — one memo-host sync, one substrate, one condensation — with a
+/// per-item sink that emits each target the moment its pool task finishes.
+/// Open documents were ordered first by prepare, so they converge first.
+/// The generation watch aborts disowned tides at item boundaries; the final
+/// event carries the uncovered remainder for the fallback arm.
 pub fn collect_tide_workspace_republish_streaming(
     job: TideWorkspaceRepublishJobV0,
-    emit: &mut dyn FnMut(TideWorkspaceRepublishResultV0) -> bool,
+    emit: &(dyn Fn(TideWorkspaceRepublishResultV0) -> bool + Sync),
 ) {
-    let chunk_count = job.uris.len().div_ceil(TIDE_REPUBLISH_STREAM_CHUNK).max(1);
-    for (chunk_index, chunk) in job.uris.chunks(TIDE_REPUBLISH_STREAM_CHUNK).enumerate() {
-        let final_chunk = chunk_index + 1 == chunk_count;
-        if job.gen_watch.load(Ordering::Relaxed) != job.generation {
-            crate::loop_trace!(
-                "republish-tide aborted between chunks gen={} at chunk {}",
-                job.generation,
-                chunk_index
-            );
+    let covered = std::sync::Mutex::new(std::collections::BTreeSet::<usize>::new());
+    let sink =
+        |index: usize,
+         diagnostics: serde_json::Value,
+         disk_cache_slot: Option<crate::disk_cache::DiskDiagnosticsCacheSlotV0>| {
+            if let Ok(mut covered) = covered.lock() {
+                covered.insert(index);
+            }
+            let Some(uri) = job.uris.get(index) else {
+                return;
+            };
             let _ = emit(TideWorkspaceRepublishResultV0 {
                 generation: job.generation,
-                items: Vec::new(),
-                uncovered_uris: Vec::new(),
-                final_chunk: true,
-            });
-            return;
-        }
-        let mut wave = crate::parallel_style_wave::resolved_parallel_style_wave_targets_with_abort(
-            job.snapshot.shell_state(),
-            chunk,
-            crate::parallel_style_wave::PARALLEL_STYLE_WAVE_MIN_PARALLEL_TARGETS,
-            Some((job.gen_watch.as_ref(), job.generation)),
-        );
-        let mut items = Vec::new();
-        let mut uncovered_uris = Vec::new();
-        for (index, uri) in chunk.iter().enumerate() {
-            match wave.remove(&index) {
-                Some(resolved) => items.push(TideWorkspaceRepublishItemV0 {
+                items: vec![TideWorkspaceRepublishItemV0 {
                     uri: uri.clone(),
-                    diagnostics: resolved.diagnostics,
-                    disk_cache_slot: resolved.disk_cache_slot,
-                }),
-                None => uncovered_uris.push(uri.clone()),
-            }
-        }
-        crate::loop_trace!(
-            "republish-tide chunk gen={} index={} items={} uncovered={} final={}",
-            job.generation,
-            chunk_index,
-            items.len(),
-            uncovered_uris.len(),
-            final_chunk
-        );
-        if !emit(TideWorkspaceRepublishResultV0 {
-            generation: job.generation,
-            items,
-            uncovered_uris,
-            final_chunk,
-        }) {
-            return;
-        }
-    }
+                    diagnostics,
+                    disk_cache_slot,
+                }],
+                uncovered_uris: Vec::new(),
+                final_chunk: false,
+            });
+        };
+    let _ = crate::parallel_style_wave::resolved_parallel_style_wave_targets_with_abort_and_sink(
+        job.snapshot.shell_state(),
+        job.uris.as_slice(),
+        crate::parallel_style_wave::PARALLEL_STYLE_WAVE_MIN_PARALLEL_TARGETS,
+        Some((job.gen_watch.as_ref(), job.generation)),
+        Some(&sink),
+    );
+    let covered = covered.into_inner().unwrap_or_default();
+    let uncovered_uris = job
+        .uris
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !covered.contains(index))
+        .map(|(_, uri)| uri.clone())
+        .collect::<Vec<_>>();
+    crate::loop_trace!(
+        "republish-tide collected gen={} covered={} uncovered={}",
+        job.generation,
+        covered.len(),
+        uncovered_uris.len()
+    );
+    let _ = emit(TideWorkspaceRepublishResultV0 {
+        generation: job.generation,
+        items: Vec::new(),
+        uncovered_uris,
+        final_chunk: true,
+    });
 }
 
 /// Loop-side apply for ONE item — the caller pumps a bounded chunk per tick

--- a/rust/crates/omena-lsp-server/src/tide_republish.rs
+++ b/rust/crates/omena-lsp-server/src/tide_republish.rs
@@ -1,0 +1,182 @@
+//! M3: the off-loop workspace-republish executor (rfcs#111 §8.5, §12 M3).
+//!
+//! `prepare` flushes the republish lane through its settle gate on the loop
+//! and captures a copy-on-write query snapshot; `collect` runs the
+//! abort-capable parallel wave against that snapshot on a worker thread —
+//! the loop stays free; `apply` publishes loop-side in canonical order under
+//! the loop's per-tick chunk budget, writing behind through the LOOP state's
+//! disk-cache session (the snapshot carries a default session on purpose).
+//! A settle-window reopen bumps the lane generation: the wave aborts at the
+//! next item boundary and pending applies are dropped — their keys are
+//! republished by the reopened window's tide, and the publication order key
+//! forbids any stale overwrite.
+
+use crate::diagnostics_follow_up::{
+    TIDE_REPUBLISH_LANE_CONFIG, workspace_republish_frontier_passed,
+};
+use crate::disk_cache::DiskDiagnosticsCacheSlotV0;
+use crate::lsp_output::ScheduledLspOutput;
+use crate::protocol::is_style_document_uri;
+use crate::state::LspQuerySnapshotV0;
+use crate::tide::TideGateInputsV0;
+use crate::{LspDocumentOrigin, LspShellState};
+use serde_json::Value;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug)]
+pub struct TideWorkspaceRepublishJobV0 {
+    snapshot: LspQuerySnapshotV0,
+    uris: Vec<String>,
+    pub generation: u64,
+    gen_watch: Arc<AtomicU64>,
+}
+
+#[derive(Debug)]
+pub struct TideWorkspaceRepublishItemV0 {
+    pub(crate) uri: String,
+    pub(crate) diagnostics: Value,
+    pub(crate) disk_cache_slot: Option<DiskDiagnosticsCacheSlotV0>,
+}
+
+#[derive(Debug)]
+pub struct TideWorkspaceRepublishResultV0 {
+    pub generation: u64,
+    pub items: Vec<TideWorkspaceRepublishItemV0>,
+    /// Wave-ineligible targets in canonical order. When the tide is still
+    /// current at completion these fall back to the per-file deferred arm;
+    /// a disowned tide drops them (the reopened window covers the corpus).
+    pub uncovered_uris: Vec<String>,
+}
+
+/// Gate evaluation + snapshot capture, on the loop. `idle` is the courtesy
+/// input (no recent client message); aging overrides it after
+/// [`TIDE_REPUBLISH_LANE_CONFIG`]'s bound, the frontier never.
+pub fn prepare_tide_workspace_republish_job(
+    state: &mut LspShellState,
+    idle: bool,
+) -> Option<TideWorkspaceRepublishJobV0> {
+    if !state.external_sif_refresh_deferred {
+        return None;
+    }
+    let inputs = TideGateInputsV0 {
+        frontier_passed: workspace_republish_frontier_passed(state),
+        idle,
+    };
+    let flush = state.tide_republish_lane.try_flush(
+        inputs,
+        state.tide_tick,
+        &TIDE_REPUBLISH_LANE_CONFIG,
+    )?;
+    state
+        .tide_republish_gen_watch
+        .store(flush.generation, Ordering::Relaxed);
+    let uris: Vec<String> = state
+        .documents
+        .values()
+        .filter(|document| {
+            document.origin == LspDocumentOrigin::Local
+                && is_style_document_uri(document.uri.as_str())
+        })
+        .map(|document| document.uri.clone())
+        .collect();
+    if uris.is_empty() {
+        state.tide_republish_lane.tide_completed(flush.generation);
+        return None;
+    }
+    crate::loop_trace!(
+        "republish-tide prepared gen={} targets={}",
+        flush.generation,
+        uris.len()
+    );
+    Some(TideWorkspaceRepublishJobV0 {
+        snapshot: state.query_snapshot(),
+        uris,
+        generation: flush.generation,
+        gen_watch: Arc::clone(&state.tide_republish_gen_watch),
+    })
+}
+
+/// Worker-side compute: the shared-graph parallel wave over the snapshot,
+/// with item-boundary generation checks. Returns per-target values in
+/// canonical order plus the uncovered remainder.
+pub fn collect_tide_workspace_republish(
+    job: TideWorkspaceRepublishJobV0,
+) -> TideWorkspaceRepublishResultV0 {
+    let mut wave = crate::parallel_style_wave::resolved_parallel_style_wave_targets_with_abort(
+        job.snapshot.shell_state(),
+        job.uris.as_slice(),
+        crate::parallel_style_wave::PARALLEL_STYLE_WAVE_MIN_PARALLEL_TARGETS,
+        Some((job.gen_watch.as_ref(), job.generation)),
+    );
+    let mut items = Vec::new();
+    let mut uncovered_uris = Vec::new();
+    for (index, uri) in job.uris.iter().enumerate() {
+        match wave.remove(&index) {
+            Some(resolved) => items.push(TideWorkspaceRepublishItemV0 {
+                uri: uri.clone(),
+                diagnostics: resolved.diagnostics,
+                disk_cache_slot: resolved.disk_cache_slot,
+            }),
+            None => uncovered_uris.push(uri.clone()),
+        }
+    }
+    crate::loop_trace!(
+        "republish-tide collected gen={} items={} uncovered={}",
+        job.generation,
+        items.len(),
+        uncovered_uris.len()
+    );
+    TideWorkspaceRepublishResultV0 {
+        generation: job.generation,
+        items,
+        uncovered_uris,
+    }
+}
+
+/// Loop-side apply for ONE item — the caller pumps a bounded chunk per tick
+/// (I4) and must have verified the tide generation is still current.
+/// Write-behind runs through the loop state's real disk-cache session, then
+/// the tiered publish emits in the same shape as every other arm.
+pub fn apply_tide_workspace_republish_item(
+    state: &mut LspShellState,
+    item: TideWorkspaceRepublishItemV0,
+) -> Vec<ScheduledLspOutput> {
+    if let Some(slot) = item.disk_cache_slot.as_ref() {
+        slot.store_write_behind(state, &item.diagnostics);
+    }
+    crate::diagnostics_scheduler::publish_tiered_diagnostics_notifications(
+        state,
+        item.uri.as_str(),
+        item.diagnostics,
+    )
+}
+
+/// Completion: re-arm the lane; when the tide is still current, uncovered
+/// targets re-enter the per-file deferred arm so no key is silently skipped.
+pub fn complete_tide_workspace_republish(
+    state: &mut LspShellState,
+    generation: u64,
+    uncovered_uris: Vec<String>,
+) -> crate::LspDiagnosticsFollowUpEffectsV0 {
+    let current = state.tide_republish_lane.generation() == generation;
+    state.tide_republish_lane.tide_completed(generation);
+    if !current || uncovered_uris.is_empty() {
+        return crate::LspDiagnosticsFollowUpEffectsV0::default();
+    }
+    crate::loop_trace!(
+        "republish-tide leftovers gen={} n={}",
+        generation,
+        uncovered_uris.len()
+    );
+    let effects = crate::diagnostics_scheduler::run_diagnostics_schedule_effects(
+        state,
+        crate::diagnostics_scheduler::DiagnosticsScheduleEvent::WatchedFiles {
+            uris: uncovered_uris,
+        },
+    );
+    crate::LspDiagnosticsFollowUpEffectsV0 {
+        outputs: effects.outputs,
+        deferred_diagnostics: effects.deferred_diagnostics,
+    }
+}

--- a/rust/crates/omena-lsp-server/src/tide_republish.rs
+++ b/rust/crates/omena-lsp-server/src/tide_republish.rs
@@ -43,11 +43,21 @@ pub struct TideWorkspaceRepublishItemV0 {
 pub struct TideWorkspaceRepublishResultV0 {
     pub generation: u64,
     pub items: Vec<TideWorkspaceRepublishItemV0>,
-    /// Wave-ineligible targets in canonical order. When the tide is still
-    /// current at completion these fall back to the per-file deferred arm;
-    /// a disowned tide drops them (the reopened window covers the corpus).
+    /// Wave-ineligible targets of THIS chunk. When the tide is still current
+    /// at completion these fall back to the per-file deferred arm; a
+    /// disowned tide drops them (the reopened window covers the corpus).
     pub uncovered_uris: Vec<String>,
+    /// The last chunk of the tide: the loop completes the tide once this
+    /// arrives and the apply queue drains.
+    pub final_chunk: bool,
 }
+
+/// Streaming chunk size (rfcs#111 §8.5): the wave runs per chunk against the
+/// SAME snapshot — the memo host diff-syncs to a no-op after the first chunk
+/// — so covered values reach the editor as the tide progresses instead of at
+/// the end. Open documents are ordered first (see prepare), so the files the
+/// user is looking at converge within the first chunks.
+pub const TIDE_REPUBLISH_STREAM_CHUNK: usize = 8;
 
 /// Gate evaluation + snapshot capture, on the loop. `idle` is the courtesy
 /// input (no recent client message); aging overrides it after
@@ -71,15 +81,24 @@ pub fn prepare_tide_workspace_republish_job(
     state
         .tide_republish_gen_watch
         .store(flush.generation, Ordering::Relaxed);
-    let uris: Vec<String> = state
-        .documents
-        .values()
-        .filter(|document| {
-            document.origin == LspDocumentOrigin::Local
-                && is_style_document_uri(document.uri.as_str())
-        })
-        .map(|document| document.uri.clone())
-        .collect();
+    // Open documents first — the user is looking at them — then the rest;
+    // canonical order within each group. Chunked streaming below turns this
+    // ordering into convergence latency for the open files.
+    let mut uris: Vec<String> = Vec::new();
+    let mut unopened: Vec<String> = Vec::new();
+    for document in state.documents.values() {
+        if document.origin != LspDocumentOrigin::Local
+            || !is_style_document_uri(document.uri.as_str())
+        {
+            continue;
+        }
+        if state.has_open_document_uri(document.uri.as_str()) {
+            uris.push(document.uri.clone());
+        } else {
+            unopened.push(document.uri.clone());
+        }
+    }
+    uris.extend(unopened);
     if uris.is_empty() {
         state.tide_republish_lane.tide_completed(flush.generation);
         return None;
@@ -97,40 +116,67 @@ pub fn prepare_tide_workspace_republish_job(
     })
 }
 
-/// Worker-side compute: the shared-graph parallel wave over the snapshot,
-/// with item-boundary generation checks. Returns per-target values in
-/// canonical order plus the uncovered remainder.
-pub fn collect_tide_workspace_republish(
+/// Worker-side compute, streaming (rfcs#111 §8.5): the shared-graph parallel
+/// wave runs per chunk against the SAME snapshot — the first chunk pays the
+/// memo-host sync, later chunks diff-sync to a no-op — and each chunk's
+/// covered values are emitted immediately. `emit` returns false when the
+/// receiver is gone; the generation watch is checked between chunks AND at
+/// item boundaries inside the wave.
+pub fn collect_tide_workspace_republish_streaming(
     job: TideWorkspaceRepublishJobV0,
-) -> TideWorkspaceRepublishResultV0 {
-    let mut wave = crate::parallel_style_wave::resolved_parallel_style_wave_targets_with_abort(
-        job.snapshot.shell_state(),
-        job.uris.as_slice(),
-        crate::parallel_style_wave::PARALLEL_STYLE_WAVE_MIN_PARALLEL_TARGETS,
-        Some((job.gen_watch.as_ref(), job.generation)),
-    );
-    let mut items = Vec::new();
-    let mut uncovered_uris = Vec::new();
-    for (index, uri) in job.uris.iter().enumerate() {
-        match wave.remove(&index) {
-            Some(resolved) => items.push(TideWorkspaceRepublishItemV0 {
-                uri: uri.clone(),
-                diagnostics: resolved.diagnostics,
-                disk_cache_slot: resolved.disk_cache_slot,
-            }),
-            None => uncovered_uris.push(uri.clone()),
+    emit: &mut dyn FnMut(TideWorkspaceRepublishResultV0) -> bool,
+) {
+    let chunk_count = job.uris.len().div_ceil(TIDE_REPUBLISH_STREAM_CHUNK).max(1);
+    for (chunk_index, chunk) in job.uris.chunks(TIDE_REPUBLISH_STREAM_CHUNK).enumerate() {
+        let final_chunk = chunk_index + 1 == chunk_count;
+        if job.gen_watch.load(Ordering::Relaxed) != job.generation {
+            crate::loop_trace!(
+                "republish-tide aborted between chunks gen={} at chunk {}",
+                job.generation,
+                chunk_index
+            );
+            let _ = emit(TideWorkspaceRepublishResultV0 {
+                generation: job.generation,
+                items: Vec::new(),
+                uncovered_uris: Vec::new(),
+                final_chunk: true,
+            });
+            return;
         }
-    }
-    crate::loop_trace!(
-        "republish-tide collected gen={} items={} uncovered={}",
-        job.generation,
-        items.len(),
-        uncovered_uris.len()
-    );
-    TideWorkspaceRepublishResultV0 {
-        generation: job.generation,
-        items,
-        uncovered_uris,
+        let mut wave = crate::parallel_style_wave::resolved_parallel_style_wave_targets_with_abort(
+            job.snapshot.shell_state(),
+            chunk,
+            crate::parallel_style_wave::PARALLEL_STYLE_WAVE_MIN_PARALLEL_TARGETS,
+            Some((job.gen_watch.as_ref(), job.generation)),
+        );
+        let mut items = Vec::new();
+        let mut uncovered_uris = Vec::new();
+        for (index, uri) in chunk.iter().enumerate() {
+            match wave.remove(&index) {
+                Some(resolved) => items.push(TideWorkspaceRepublishItemV0 {
+                    uri: uri.clone(),
+                    diagnostics: resolved.diagnostics,
+                    disk_cache_slot: resolved.disk_cache_slot,
+                }),
+                None => uncovered_uris.push(uri.clone()),
+            }
+        }
+        crate::loop_trace!(
+            "republish-tide chunk gen={} index={} items={} uncovered={} final={}",
+            job.generation,
+            chunk_index,
+            items.len(),
+            uncovered_uris.len(),
+            final_chunk
+        );
+        if !emit(TideWorkspaceRepublishResultV0 {
+            generation: job.generation,
+            items,
+            uncovered_uris,
+            final_chunk,
+        }) {
+            return;
+        }
     }
 }
 

--- a/rust/crates/omena-lsp-server/src/workspace_index.rs
+++ b/rust/crates/omena-lsp-server/src/workspace_index.rs
@@ -175,13 +175,15 @@ pub fn apply_background_workspace_index_result(
         state
             .tide_ledger
             .advance(&[crate::tide::TideInputKindV0::DocumentSet]);
+        state.tide_reopen_republish_window();
         crate::loop_trace!(
             "index-admit deposits sif demand (admitted={})",
             bridge_source_uris.len()
         );
+        let tick = state.tide_tick;
         state
             .tide_sif_lane
-            .deposit(crate::tide::TideDemandV0::SifRefresh, 0);
+            .deposit(crate::tide::TideDemandV0::SifRefresh, tick);
     }
     crate::refresh_external_sifs_for_bridge_source_delta(
         state,

--- a/rust/crates/omena-lsp-server/src/workspace_index.rs
+++ b/rust/crates/omena-lsp-server/src/workspace_index.rs
@@ -166,15 +166,22 @@ pub fn apply_background_workspace_index_result(
     let mut bridge_source_uris = indexed_style_uris;
     bridge_source_uris.extend(admitted_foreign_uris);
     let next_bridge_sources = crate::bridge_sources_for_style_uris(state, &bridge_source_uris);
-    if !bridge_source_uris.is_empty() {
-        // Newly admitted style documents owe an external-SIF refresh even
-        // when the bridge-source *summary* is unchanged: the deferred refresh
-        // job is what discovers bridge SIFs from the newly admitted document
-        // set (and its follow-up republishes diagnostics against the settled
-        // resolution state). The debt is settled ONCE at index quiesce below
-        // — scheduling per admit wave races the in-flight job's revision and
-        // multiplies full-workspace diagnostics rounds.
-        state.external_sif_refresh_owed_for_admitted_styles = true;
+    if state.external_sif_refresh_deferred && !bridge_source_uris.is_empty() {
+        // Newly admitted style documents mutate the corpus input: the ledger
+        // advance stales any in-flight SIF job built on the smaller corpus,
+        // and the idempotent deposit owes ONE refresh whose settle gate holds
+        // the flush until the index frontier passes — pending == 0. The
+        // immediate arm keeps its delta-scoped invariant untouched.
+        state
+            .tide_ledger
+            .advance(&[crate::tide::TideInputKindV0::DocumentSet]);
+        crate::loop_trace!(
+            "index-admit deposits sif demand (admitted={})",
+            bridge_source_uris.len()
+        );
+        state
+            .tide_sif_lane
+            .deposit(crate::tide::TideDemandV0::SifRefresh, 0);
     }
     crate::refresh_external_sifs_for_bridge_source_delta(
         state,
@@ -188,18 +195,6 @@ pub fn apply_background_workspace_index_result(
         result.exhausted
     );
     state.workspace_index_pending_file_count = result.pending_file_count;
-    // Deferred arm only: the immediate arm keeps its delta-scoped refresh
-    // invariant (an index apply never reruns the whole-state lockfile
-    // refresh); the deferred arm settles the admission debt as ONE dirty
-    // mark at quiesce, which the loop turns into a single refresh job.
-    if state.external_sif_refresh_deferred
-        && result.pending_file_count == 0
-        && state.external_sif_refresh_owed_for_admitted_styles
-    {
-        state.external_sif_refresh_owed_for_admitted_styles = false;
-        crate::loop_trace!("index-quiesce schedules sif refresh");
-        crate::refresh_external_sifs_for_state(state);
-    }
     if result.exhausted {
         state.workspace_style_index_exhausted_count += 1;
     }

--- a/rust/crates/omena-query/src/style/diagnostics/cascade_runtime.rs
+++ b/rust/crates/omena-query/src/style/diagnostics/cascade_runtime.rs
@@ -107,6 +107,27 @@ pub(super) fn attach_omena_query_runtime_state_inline_overrides_for_workspace(
         resolution_inputs,
         resolver_identity_index,
     );
+    attach_omena_query_runtime_state_inline_overrides_from_overrides(summary, inline_overrides);
+}
+
+/// The shared-pass arm: the per-wave bucket map replaces the per-target
+/// source sweep; the attach body is shared verbatim below.
+pub(in crate::style) fn attach_omena_query_runtime_state_inline_overrides_with_shared(
+    target_style_path: &str,
+    summary: &mut OmenaQueryStyleDiagnosticsForFileV0,
+    overrides_by_style: &BTreeMap<String, Vec<OmenaQueryInlineStyleRuntimeOverrideV0>>,
+) {
+    let inline_overrides = overrides_by_style
+        .get(target_style_path)
+        .cloned()
+        .unwrap_or_default();
+    attach_omena_query_runtime_state_inline_overrides_from_overrides(summary, inline_overrides);
+}
+
+fn attach_omena_query_runtime_state_inline_overrides_from_overrides(
+    summary: &mut OmenaQueryStyleDiagnosticsForFileV0,
+    inline_overrides: Vec<OmenaQueryInlineStyleRuntimeOverrideV0>,
+) {
     if inline_overrides.is_empty() {
         return;
     }
@@ -196,11 +217,33 @@ fn collect_omena_query_inline_style_runtime_overrides_for_style(
     resolution_inputs: &OmenaQueryStyleResolutionInputsV0,
     resolver_identity_index: Option<&OmenaResolverStyleModuleConfirmationIdentityIndexV0>,
 ) -> Vec<OmenaQueryInlineStyleRuntimeOverrideV0> {
+    collect_omena_query_inline_style_runtime_overrides_by_style(
+        style_sources,
+        source_documents,
+        resolution_inputs,
+        resolver_identity_index,
+    )
+    .remove(target_style_path)
+    .unwrap_or_default()
+}
+
+/// Target-INDEPENDENT core of the inline-override attach (rfcs#111 C1 slice
+/// 2): every source document is parsed, its imports resolved, and its inline
+/// style declarations attributed ONCE — bucketed by owning style path — so a
+/// wave shares one pass over the sources instead of one per target. The
+/// per-target consumer is a map lookup; per-bucket ordering matches the
+/// single-target arm exactly (same collection order, same sort, same dedup).
+pub(in crate::style) fn collect_omena_query_inline_style_runtime_overrides_by_style(
+    style_sources: &[OmenaQueryStyleSourceInputV0],
+    source_documents: &[OmenaQuerySourceDocumentInputV0],
+    resolution_inputs: &OmenaQueryStyleResolutionInputsV0,
+    resolver_identity_index: Option<&OmenaResolverStyleModuleConfirmationIdentityIndexV0>,
+) -> BTreeMap<String, Vec<OmenaQueryInlineStyleRuntimeOverrideV0>> {
     let available_style_paths = style_sources
         .iter()
         .map(|source| source.style_path.as_str())
         .collect::<BTreeSet<_>>();
-    let mut overrides = Vec::new();
+    let mut overrides_by_style = BTreeMap::<String, Vec<_>>::new();
 
     for document in source_documents {
         let imports = summarize_omena_query_source_import_declarations_for_source_language(
@@ -246,27 +289,35 @@ fn collect_omena_query_inline_style_runtime_overrides_for_style(
             classnames_bind_bindings,
         );
         for declaration in index.inline_style_declarations {
-            if declaration.target_style_uri.as_deref() != Some(target_style_path) {
+            let Some(target_style_uri) = declaration.target_style_uri.as_deref() else {
                 continue;
-            }
-            overrides.push(OmenaQueryInlineStyleRuntimeOverrideV0 {
-                source_path: document.source_path.clone(),
-                range: parser_range_for_byte_span(&document.source_source, declaration.byte_span),
-                property_name: declaration.property_name,
-                value: declaration.value,
-                cascade_tier: declaration.cascade_tier,
-                static_value: declaration.static_value,
-            });
+            };
+            overrides_by_style
+                .entry(target_style_uri.to_string())
+                .or_default()
+                .push(OmenaQueryInlineStyleRuntimeOverrideV0 {
+                    source_path: document.source_path.clone(),
+                    range: parser_range_for_byte_span(
+                        &document.source_source,
+                        declaration.byte_span,
+                    ),
+                    property_name: declaration.property_name,
+                    value: declaration.value,
+                    cascade_tier: declaration.cascade_tier,
+                    static_value: declaration.static_value,
+                });
         }
     }
 
-    overrides.sort_by(|left, right| {
-        left.source_path
-            .cmp(&right.source_path)
-            .then_with(|| left.range.start.line.cmp(&right.range.start.line))
-            .then_with(|| left.range.start.character.cmp(&right.range.start.character))
-            .then_with(|| left.property_name.cmp(&right.property_name))
-    });
-    overrides.dedup();
-    overrides
+    for overrides in overrides_by_style.values_mut() {
+        overrides.sort_by(|left, right| {
+            left.source_path
+                .cmp(&right.source_path)
+                .then_with(|| left.range.start.line.cmp(&right.range.start.line))
+                .then_with(|| left.range.start.character.cmp(&right.range.start.character))
+                .then_with(|| left.property_name.cmp(&right.property_name))
+        });
+        overrides.dedup();
+    }
+    overrides_by_style
 }

--- a/rust/crates/omena-query/src/style/diagnostics/cross_file_scc.rs
+++ b/rust/crates/omena-query/src/style/diagnostics/cross_file_scc.rs
@@ -13,6 +13,29 @@ pub(super) fn summarize_omena_query_unified_cross_file_scc_diagnostics_for_works
     package_manifests: &[OmenaQueryStylePackageManifestV0],
     substrate: &OmenaQueryWorkspaceDiagnosticsSubstrateV0,
 ) -> Vec<OmenaQueryStyleDiagnosticV0> {
+    let report = collect_omena_query_unified_cross_file_scc_report_shared(
+        style_sources,
+        source_documents,
+        package_manifests,
+        substrate,
+    );
+    summarize_omena_query_unified_cross_file_scc_diagnostics_from_report(
+        target_style_path,
+        target_style_source,
+        &report,
+    )
+}
+
+/// Target-INDEPENDENT core of the cross-file SCC pass (rfcs#111 C1 slice 2):
+/// the workspace cross-file summary, the unified hypergraph, and the SCC
+/// report — identical for every target of a wave.
+#[cfg(feature = "hypergraph-ifds")]
+pub(in crate::style) fn collect_omena_query_unified_cross_file_scc_report_shared(
+    style_sources: &[OmenaQueryStyleSourceInputV0],
+    source_documents: &[OmenaQuerySourceDocumentInputV0],
+    package_manifests: &[OmenaQueryStylePackageManifestV0],
+    substrate: &OmenaQueryWorkspaceDiagnosticsSubstrateV0,
+) -> crate::OmenaQueryUnifiedCrossFileSccReportV0 {
     let summary = super::super::cross_file_summary::summarize_omena_query_workspace_cross_file_summary_with_substrate(
         style_sources,
         source_documents,
@@ -22,7 +45,18 @@ pub(super) fn summarize_omena_query_unified_cross_file_scc_diagnostics_for_works
         &substrate.sass_resolution_without_path_mappings,
     );
     let hypergraph = super::super::summarize_omena_query_unified_cross_file_hypergraph(&summary);
-    let report = super::super::summarize_omena_query_unified_cross_file_scc_report(&hypergraph);
+    super::super::summarize_omena_query_unified_cross_file_scc_report(&hypergraph)
+}
+
+/// The per-target remainder: filter the shared report for target-crossing
+/// composes cycles. Byte-identical to the inline arm (same construction,
+/// clone instead of move).
+#[cfg(feature = "hypergraph-ifds")]
+pub(in crate::style) fn summarize_omena_query_unified_cross_file_scc_diagnostics_from_report(
+    target_style_path: &str,
+    target_style_source: &str,
+    report: &crate::OmenaQueryUnifiedCrossFileSccReportV0,
+) -> Vec<OmenaQueryStyleDiagnosticV0> {
     if report.sccs.is_empty() {
         return Vec::new();
     }
@@ -37,7 +71,8 @@ pub(super) fn summarize_omena_query_unified_cross_file_scc_diagnostics_for_works
     let mut emitted = BTreeSet::new();
     report
         .sccs
-        .into_iter()
+        .iter()
+        .cloned()
         .filter(|scc| scc.cross_file)
         .filter(|scc| scc.style_paths.iter().any(|path| path == target_style_path))
         .filter(|scc| {

--- a/rust/crates/omena-query/src/style/diagnostics/mod.rs
+++ b/rust/crates/omena-query/src/style/diagnostics/mod.rs
@@ -20,6 +20,11 @@ mod shared;
 mod single_file;
 mod source_usage;
 mod substrate;
+
+#[cfg(feature = "hypergraph-ifds")]
+pub(in crate::style) use cross_file_scc::collect_omena_query_unified_cross_file_scc_report_shared;
+pub(in crate::style) use source_usage::collect_omena_query_unused_selector_shared;
+pub(in crate::style) use substrate::OmenaQueryWorkspaceSharedPassProductsV0;
 mod types;
 
 use cascade_runtime::{
@@ -370,6 +375,43 @@ pub(in crate::style) fn summarize_omena_query_style_diagnostics_for_workspace_fi
     substrate: &OmenaQueryWorkspaceDiagnosticsSubstrateV0,
     resolver_identity_index: Option<&OmenaResolverStyleModuleConfirmationIdentityIndexV0>,
 ) -> Option<OmenaQueryStyleDiagnosticsForFileV0> {
+    summarize_omena_query_style_diagnostics_for_workspace_file_with_external_mode_and_sifs_and_resolution_inputs_and_suppression_mode_with_substrate_and_shared(
+        target_style_path,
+        style_sources,
+        source_documents,
+        package_manifests,
+        classname_transform,
+        external_mode,
+        external_sifs,
+        resolution_inputs,
+        suppression_mode,
+        substrate,
+        resolver_identity_index,
+        None,
+    )
+}
+
+/// The shared-pass arm (rfcs#111 C1 slice 2): when `shared_passes` is `Some`
+/// the target-independent pass cores — source-selector usage resolution and
+/// the cross-file SCC report — come precomputed from the wave prepare
+/// instead of being rebuilt per target. `None` keeps the per-call arm; both
+/// arms are byte-identical by construction and gated end-to-end by the
+/// wave-vs-serial publish parity oracle.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::style) fn summarize_omena_query_style_diagnostics_for_workspace_file_with_external_mode_and_sifs_and_resolution_inputs_and_suppression_mode_with_substrate_and_shared(
+    target_style_path: &str,
+    style_sources: &[OmenaQueryStyleSourceInputV0],
+    source_documents: &[OmenaQuerySourceDocumentInputV0],
+    package_manifests: &[OmenaQueryStylePackageManifestV0],
+    classname_transform: Option<&str>,
+    external_mode: OmenaQueryExternalModuleModeV0,
+    external_sifs: &[OmenaQueryExternalSifInputV0],
+    resolution_inputs: &OmenaQueryStyleResolutionInputsV0,
+    suppression_mode: OmenaQueryDiagnosticSuppressionModeV0,
+    substrate: &OmenaQueryWorkspaceDiagnosticsSubstrateV0,
+    resolver_identity_index: Option<&OmenaResolverStyleModuleConfirmationIdentityIndexV0>,
+    shared_passes: Option<&substrate::OmenaQueryWorkspaceSharedPassProductsV0>,
+) -> Option<OmenaQueryStyleDiagnosticsForFileV0> {
     let target = style_sources
         .iter()
         .find(|source| source.style_path == target_style_path)?;
@@ -429,6 +471,27 @@ pub(in crate::style) fn summarize_omena_query_style_diagnostics_for_workspace_fi
             substrate,
         ),
     );
+    #[cfg(feature = "hypergraph-ifds")]
+    match shared_passes.and_then(|shared| shared.cross_file_scc_report.as_ref()) {
+        Some(report) => summary.diagnostics.extend(
+            cross_file_scc::summarize_omena_query_unified_cross_file_scc_diagnostics_from_report(
+                target_style_path,
+                &target.style_source,
+                report,
+            ),
+        ),
+        None => summary.diagnostics.extend(
+            summarize_omena_query_unified_cross_file_scc_diagnostics_for_workspace(
+                target_style_path,
+                &target.style_source,
+                style_sources,
+                source_documents,
+                package_manifests,
+                substrate,
+            ),
+        ),
+    }
+    #[cfg(not(feature = "hypergraph-ifds"))]
     summary.diagnostics.extend(
         summarize_omena_query_unified_cross_file_scc_diagnostics_for_workspace(
             target_style_path,
@@ -453,20 +516,35 @@ pub(in crate::style) fn summarize_omena_query_style_diagnostics_for_workspace_fi
             &substrate.sass_resolution,
         ),
     );
-    summary.diagnostics.extend(
-        summarize_omena_query_unused_selector_style_diagnostics_with_path_mappings_from_entries(
-            target_style_path,
-            &target.style_source,
-            &substrate.style_fact_entries,
-            source_documents,
-            package_manifests,
-            classname_transform,
-            resolution_inputs.bundler_path_mappings.as_slice(),
-            resolution_inputs.tsconfig_path_mappings.as_slice(),
-            resolution_inputs.disk_style_path_identities.as_slice(),
-            resolver_identity_index,
+    match shared_passes {
+        Some(shared) => {
+            // `None` means no source documents — the same emptiness the
+            // per-call arm's early return produces.
+            if let Some(unused_selector) = shared.unused_selector.as_ref() {
+                summary.diagnostics.extend(
+                    source_usage::summarize_omena_query_unused_selector_style_diagnostics_with_shared(
+                        target_style_path,
+                        &target.style_source,
+                        unused_selector,
+                    ),
+                );
+            }
+        }
+        None => summary.diagnostics.extend(
+            summarize_omena_query_unused_selector_style_diagnostics_with_path_mappings_from_entries(
+                target_style_path,
+                &target.style_source,
+                &substrate.style_fact_entries,
+                source_documents,
+                package_manifests,
+                classname_transform,
+                resolution_inputs.bundler_path_mappings.as_slice(),
+                resolution_inputs.tsconfig_path_mappings.as_slice(),
+                resolution_inputs.disk_style_path_identities.as_slice(),
+                resolver_identity_index,
+            ),
         ),
-    );
+    }
     summary.diagnostics.extend(
         summarize_omena_query_replica_ensemble_inconsistency_diagnostics_for_workspace(
             target_style_path,

--- a/rust/crates/omena-query/src/style/diagnostics/mod.rs
+++ b/rust/crates/omena-query/src/style/diagnostics/mod.rs
@@ -21,6 +21,7 @@ mod single_file;
 mod source_usage;
 mod substrate;
 
+pub(in crate::style) use cascade_runtime::collect_omena_query_inline_style_runtime_overrides_by_style;
 #[cfg(feature = "hypergraph-ifds")]
 pub(in crate::style) use cross_file_scc::collect_omena_query_unified_cross_file_scc_report_shared;
 pub(in crate::style) use source_usage::collect_omena_query_unused_selector_shared;
@@ -664,14 +665,23 @@ pub(in crate::style) fn summarize_omena_query_style_diagnostics_for_workspace_fi
         );
         push_omena_query_ready_surface(&mut summary.ready_surfaces, "strictnessSigilGating");
     }
-    attach_omena_query_runtime_state_inline_overrides_for_workspace(
-        target_style_path,
-        &mut summary,
-        style_sources,
-        source_documents,
-        resolution_inputs,
-        resolver_identity_index,
-    );
+    match shared_passes.and_then(|shared| shared.inline_style_overrides_by_style.as_ref()) {
+        Some(overrides_by_style) => {
+            cascade_runtime::attach_omena_query_runtime_state_inline_overrides_with_shared(
+                target_style_path,
+                &mut summary,
+                overrides_by_style,
+            )
+        }
+        None => attach_omena_query_runtime_state_inline_overrides_for_workspace(
+            target_style_path,
+            &mut summary,
+            style_sources,
+            source_documents,
+            resolution_inputs,
+            resolver_identity_index,
+        ),
+    }
     push_omena_query_ready_surface(
         &mut summary.ready_surfaces,
         "runtimeStateInlineStyleOverrides",

--- a/rust/crates/omena-query/src/style/diagnostics/source_usage.rs
+++ b/rust/crates/omena-query/src/style/diagnostics/source_usage.rs
@@ -64,9 +64,19 @@ pub fn summarize_omena_query_unused_selector_style_diagnostics_with_path_mapping
 /// consumes precomputed source syntax indexes when callers provide them, while
 /// retaining the text-backed import/syntax fallback for non-indexed callers.
 #[allow(clippy::too_many_arguments)]
-pub(super) fn summarize_omena_query_unused_selector_style_diagnostics_with_path_mappings_from_entries(
-    target_style_path: &str,
-    target_source: &str,
+/// Target-INDEPENDENT core of the unused-selector pass (rfcs#111 C1 slice
+/// 2): source-side import resolution across every source document, selector
+/// usage attribution, and composes propagation — the wave computes this ONCE
+/// and every target consumes it. Owned types by construction, so the product
+/// shares behind an `Arc` without borrowing the substrate.
+pub(in crate::style) struct OmenaQueryUnusedSelectorSharedV0 {
+    used_selectors: BTreeMap<String, BTreeSet<String>>,
+    unresolved_dynamic_usage: BTreeSet<String>,
+    has_unresolved_style_import: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::style) fn collect_omena_query_unused_selector_shared(
     style_fact_entries: &[OmenaQueryStyleFactEntry],
     source_documents: &[OmenaQuerySourceDocumentInputV0],
     package_manifests: &[OmenaQueryStylePackageManifestV0],
@@ -75,9 +85,9 @@ pub(super) fn summarize_omena_query_unused_selector_style_diagnostics_with_path_
     tsconfig_path_mappings: &[OmenaResolverTsconfigPathMappingV0],
     disk_style_path_identities: &[OmenaResolverStyleModuleDiskCandidateIdentityV0],
     resolver_identity_index: Option<&OmenaResolverStyleModuleConfirmationIdentityIndexV0>,
-) -> Vec<OmenaQueryStyleDiagnosticV0> {
+) -> Option<OmenaQueryUnusedSelectorSharedV0> {
     if source_documents.is_empty() {
-        return Vec::new();
+        return None;
     }
 
     let available_style_paths = style_fact_entries
@@ -100,7 +110,26 @@ pub(super) fn summarize_omena_query_unused_selector_style_diagnostics_with_path_
             disk_style_path_identities,
             resolver_identity_index,
         });
-    if unresolved_dynamic_usage.contains(target_style_path) {
+    let composes_graph = collect_css_modules_composes_adjacency(
+        &facts_by_path,
+        &available_style_paths,
+        package_manifests,
+    );
+    propagate_omena_query_composes_usage(&composes_graph, &mut used_selectors);
+    Some(OmenaQueryUnusedSelectorSharedV0 {
+        used_selectors,
+        unresolved_dynamic_usage,
+        has_unresolved_style_import,
+    })
+}
+
+/// The per-target remainder: two set lookups plus a parse of the target.
+pub(in crate::style) fn summarize_omena_query_unused_selector_style_diagnostics_with_shared(
+    target_style_path: &str,
+    target_source: &str,
+    shared: &OmenaQueryUnusedSelectorSharedV0,
+) -> Vec<OmenaQueryStyleDiagnosticV0> {
+    if shared.unresolved_dynamic_usage.contains(target_style_path) {
         return Vec::new();
     }
     // RFC-0007-J (#50): when a source document imports a style module via a specifier we cannot
@@ -110,20 +139,14 @@ pub(super) fn summarize_omena_query_unused_selector_style_diagnostics_with_path_
     // ambiguity; the negative assertion (`unusedSelector`) must be conservative to match, instead
     // of dimming every selector in the file. Treat such documents as "possibly using" and skip the
     // lint for this target rather than emitting a wall of false positives.
-    if has_unresolved_style_import {
+    if shared.has_unresolved_style_import {
         return Vec::new();
     }
 
-    let composes_graph = collect_css_modules_composes_adjacency(
-        &facts_by_path,
-        &available_style_paths,
-        package_manifests,
-    );
-    propagate_omena_query_composes_usage(&composes_graph, &mut used_selectors);
-
     let dialect = omena_parser_dialect_for_style_path(target_style_path);
     let target_facts = collect_omena_query_omena_parser_style_facts_raw(target_source, dialect);
-    let used_in_target = used_selectors
+    let used_in_target = shared
+        .used_selectors
         .get(target_style_path)
         .cloned()
         .unwrap_or_default();
@@ -164,6 +187,38 @@ pub(super) fn summarize_omena_query_unused_selector_style_diagnostics_with_path_
             })
         })
         .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn summarize_omena_query_unused_selector_style_diagnostics_with_path_mappings_from_entries(
+    target_style_path: &str,
+    target_source: &str,
+    style_fact_entries: &[OmenaQueryStyleFactEntry],
+    source_documents: &[OmenaQuerySourceDocumentInputV0],
+    package_manifests: &[OmenaQueryStylePackageManifestV0],
+    classname_transform: Option<&str>,
+    bundler_path_mappings: &[OmenaResolverBundlerPathAliasMappingV0],
+    tsconfig_path_mappings: &[OmenaResolverTsconfigPathMappingV0],
+    disk_style_path_identities: &[OmenaResolverStyleModuleDiskCandidateIdentityV0],
+    resolver_identity_index: Option<&OmenaResolverStyleModuleConfirmationIdentityIndexV0>,
+) -> Vec<OmenaQueryStyleDiagnosticV0> {
+    let Some(shared) = collect_omena_query_unused_selector_shared(
+        style_fact_entries,
+        source_documents,
+        package_manifests,
+        classname_transform,
+        bundler_path_mappings,
+        tsconfig_path_mappings,
+        disk_style_path_identities,
+        resolver_identity_index,
+    ) else {
+        return Vec::new();
+    };
+    summarize_omena_query_unused_selector_style_diagnostics_with_shared(
+        target_style_path,
+        target_source,
+        &shared,
+    )
 }
 
 struct SourceSelectorUsageResolutionContext<'a> {

--- a/rust/crates/omena-query/src/style/diagnostics/substrate.rs
+++ b/rust/crates/omena-query/src/style/diagnostics/substrate.rs
@@ -171,3 +171,16 @@ pub(in crate::style) fn collect_sass_module_graph_reachable_style_paths<'a>(
     }
     reachable
 }
+
+/// Per-wave shared products of the target-independent pass cores (rfcs#111
+/// C1 slice 2), built once by the committed wave-substrate prepare and
+/// consumed by every target's dispatch. `None` members mean the shared form
+/// is unavailable (e.g. no source documents) and carry the SAME semantics as
+/// the per-target early returns they replace.
+pub(in crate::style) struct OmenaQueryWorkspaceSharedPassProductsV0 {
+    pub(in crate::style) unused_selector:
+        Option<super::source_usage::OmenaQueryUnusedSelectorSharedV0>,
+    #[cfg(feature = "hypergraph-ifds")]
+    pub(in crate::style) cross_file_scc_report:
+        Option<crate::OmenaQueryUnifiedCrossFileSccReportV0>,
+}

--- a/rust/crates/omena-query/src/style/diagnostics/substrate.rs
+++ b/rust/crates/omena-query/src/style/diagnostics/substrate.rs
@@ -180,6 +180,9 @@ pub(in crate::style) fn collect_sass_module_graph_reachable_style_paths<'a>(
 pub(in crate::style) struct OmenaQueryWorkspaceSharedPassProductsV0 {
     pub(in crate::style) unused_selector:
         Option<super::source_usage::OmenaQueryUnusedSelectorSharedV0>,
+    pub(in crate::style) inline_style_overrides_by_style: Option<
+        std::collections::BTreeMap<String, Vec<crate::OmenaQueryInlineStyleRuntimeOverrideV0>>,
+    >,
     #[cfg(feature = "hypergraph-ifds")]
     pub(in crate::style) cross_file_scc_report:
         Option<crate::OmenaQueryUnifiedCrossFileSccReportV0>,

--- a/rust/crates/omena-query/src/style/salsa_memo.rs
+++ b/rust/crates/omena-query/src/style/salsa_memo.rs
@@ -451,6 +451,68 @@ pub fn resolve_committed_workspace_style_diagnostics_from_view_with_identity_ind
     )
 }
 
+/// Target-INDEPENDENT per-wave state (rfcs#111, the first C1 slice): the
+/// corpus snapshot and the diagnostics substrate — all 137-entry fact/
+/// resolution clones — hoisted out of the per-target resolve. Opaque to
+/// callers; build once per wave, share behind an `Arc`, and resolve each
+/// target through the `_and_wave_substrate` variant below. Byte-identical
+/// to the per-target build by construction (same collector, same inputs).
+pub struct OmenaQueryCommittedWaveSubstrateV0 {
+    corpus: Vec<OmenaQueryStyleSourceInputV0>,
+    substrate: OmenaQueryWorkspaceDiagnosticsSubstrateV0,
+}
+
+pub fn prepare_committed_workspace_wave_substrate(
+    db: &OmenaQueryStyleMemoDatabaseV0,
+    workspace: OmenaQueryStyleWorkspaceInputV0,
+    committed_graph: &OmenaQueryCommittedStyleSemanticGraphV0,
+) -> OmenaQueryCommittedWaveSubstrateV0 {
+    let corpus = workspace
+        .files(db)
+        .iter()
+        .map(|file| OmenaQueryStyleSourceInputV0 {
+            style_path: file.style_path(db).clone(),
+            style_source: file.style_source(db).clone(),
+        })
+        .collect::<Vec<_>>();
+    let substrate = collect_omena_query_workspace_diagnostics_substrate_from_committed_graph(
+        committed_graph.style_fact_entries.clone(),
+        &committed_graph.css_modules_resolution,
+        &committed_graph.sass_module_resolution,
+        &committed_graph.sass_module_resolution_without_manifests,
+        &committed_graph.sass_module_resolution_without_path_mappings,
+        &committed_graph.sass_module_resolution_with_external_sifs,
+    );
+    OmenaQueryCommittedWaveSubstrateV0 { corpus, substrate }
+}
+
+pub fn resolve_committed_workspace_style_diagnostics_from_view_with_identity_index_and_wave_substrate(
+    db: &OmenaQueryStyleMemoDatabaseV0,
+    workspace: OmenaQueryStyleWorkspaceInputV0,
+    target: OmenaQueryStyleFileInputV0,
+    wave_substrate: &OmenaQueryCommittedWaveSubstrateV0,
+    resolver_identity_index: &OmenaResolverStyleModuleConfirmationIdentityIndexV0,
+) -> Option<OmenaQueryStyleDiagnosticsForFileV0> {
+    let target_style_path = target.style_path(db);
+    let source_documents = workspace.source_documents(db);
+    let package_manifests = workspace.package_manifests(db);
+    let external_sifs = workspace.external_sifs(db);
+    let resolution_inputs = workspace.resolution_inputs(db);
+    summarize_omena_query_style_diagnostics_for_workspace_file_with_external_mode_and_sifs_and_resolution_inputs_and_suppression_mode_with_substrate(
+        target_style_path.as_str(),
+        wave_substrate.corpus.as_slice(),
+        source_documents.as_slice(),
+        package_manifests.as_slice(),
+        None,
+        OmenaQueryExternalModuleModeV0::Auto,
+        external_sifs.as_slice(),
+        resolution_inputs,
+        OmenaQueryDiagnosticSuppressionModeV0::Apply,
+        &wave_substrate.substrate,
+        Some(resolver_identity_index),
+    )
+}
+
 pub fn resolve_committed_workspace_style_diagnostics_from_view_with_external_mode(
     db: &OmenaQueryStyleMemoDatabaseV0,
     workspace: OmenaQueryStyleWorkspaceInputV0,

--- a/rust/crates/omena-query/src/style/salsa_memo.rs
+++ b/rust/crates/omena-query/src/style/salsa_memo.rs
@@ -460,12 +460,14 @@ pub fn resolve_committed_workspace_style_diagnostics_from_view_with_identity_ind
 pub struct OmenaQueryCommittedWaveSubstrateV0 {
     corpus: Vec<OmenaQueryStyleSourceInputV0>,
     substrate: OmenaQueryWorkspaceDiagnosticsSubstrateV0,
+    shared_passes: crate::style::diagnostics::OmenaQueryWorkspaceSharedPassProductsV0,
 }
 
 pub fn prepare_committed_workspace_wave_substrate(
     db: &OmenaQueryStyleMemoDatabaseV0,
     workspace: OmenaQueryStyleWorkspaceInputV0,
     committed_graph: &OmenaQueryCommittedStyleSemanticGraphV0,
+    resolver_identity_index: Option<&OmenaResolverStyleModuleConfirmationIdentityIndexV0>,
 ) -> OmenaQueryCommittedWaveSubstrateV0 {
     let corpus = workspace
         .files(db)
@@ -483,7 +485,40 @@ pub fn prepare_committed_workspace_wave_substrate(
         &committed_graph.sass_module_resolution_without_path_mappings,
         &committed_graph.sass_module_resolution_with_external_sifs,
     );
-    OmenaQueryCommittedWaveSubstrateV0 { corpus, substrate }
+    // rfcs#111 C1 slice 2: the target-independent pass cores, computed once
+    // per wave. Arguments mirror the per-target dispatch exactly — the
+    // committed arm passes classname_transform = None (as the per-target
+    // wrapper does) and the same resolution inputs and identity index the
+    // targets will resolve with.
+    let source_documents = workspace.source_documents(db);
+    let package_manifests = workspace.package_manifests(db);
+    let resolution_inputs = workspace.resolution_inputs(db);
+    let shared_passes = crate::style::diagnostics::OmenaQueryWorkspaceSharedPassProductsV0 {
+        unused_selector: crate::style::diagnostics::collect_omena_query_unused_selector_shared(
+            &substrate.style_fact_entries,
+            source_documents.as_slice(),
+            package_manifests.as_slice(),
+            None,
+            resolution_inputs.bundler_path_mappings.as_slice(),
+            resolution_inputs.tsconfig_path_mappings.as_slice(),
+            resolution_inputs.disk_style_path_identities.as_slice(),
+            resolver_identity_index,
+        ),
+        #[cfg(feature = "hypergraph-ifds")]
+        cross_file_scc_report: Some(
+            crate::style::diagnostics::collect_omena_query_unified_cross_file_scc_report_shared(
+                corpus.as_slice(),
+                source_documents.as_slice(),
+                package_manifests.as_slice(),
+                &substrate,
+            ),
+        ),
+    };
+    OmenaQueryCommittedWaveSubstrateV0 {
+        corpus,
+        substrate,
+        shared_passes,
+    }
 }
 
 pub fn resolve_committed_workspace_style_diagnostics_from_view_with_identity_index_and_wave_substrate(
@@ -498,7 +533,7 @@ pub fn resolve_committed_workspace_style_diagnostics_from_view_with_identity_ind
     let package_manifests = workspace.package_manifests(db);
     let external_sifs = workspace.external_sifs(db);
     let resolution_inputs = workspace.resolution_inputs(db);
-    summarize_omena_query_style_diagnostics_for_workspace_file_with_external_mode_and_sifs_and_resolution_inputs_and_suppression_mode_with_substrate(
+    summarize_omena_query_style_diagnostics_for_workspace_file_with_external_mode_and_sifs_and_resolution_inputs_and_suppression_mode_with_substrate_and_shared(
         target_style_path.as_str(),
         wave_substrate.corpus.as_slice(),
         source_documents.as_slice(),
@@ -510,6 +545,7 @@ pub fn resolve_committed_workspace_style_diagnostics_from_view_with_identity_ind
         OmenaQueryDiagnosticSuppressionModeV0::Apply,
         &wave_substrate.substrate,
         Some(resolver_identity_index),
+        Some(&wave_substrate.shared_passes),
     )
 }
 

--- a/rust/crates/omena-query/src/style/salsa_memo.rs
+++ b/rust/crates/omena-query/src/style/salsa_memo.rs
@@ -504,6 +504,14 @@ pub fn prepare_committed_workspace_wave_substrate(
             resolution_inputs.disk_style_path_identities.as_slice(),
             resolver_identity_index,
         ),
+        inline_style_overrides_by_style: Some(
+            crate::style::diagnostics::collect_omena_query_inline_style_runtime_overrides_by_style(
+                corpus.as_slice(),
+                source_documents.as_slice(),
+                resolution_inputs,
+                resolver_identity_index,
+            ),
+        ),
         #[cfg(feature = "hypergraph-ifds")]
         cross_file_scc_report: Some(
             crate::style::diagnostics::collect_omena_query_unified_cross_file_scc_report_shared(

--- a/rust/crates/omena-streaming-ifds/src/lib.rs
+++ b/rust/crates/omena-streaming-ifds/src/lib.rs
@@ -615,6 +615,130 @@ pub fn summarize_streaming_ifds_cross_file_reachability_v0(
     summarize_streaming_ifds_cross_file_reachability_fast_v0(target_style_path, hyperedges).report
 }
 
+/// Target-INDEPENDENT condensation of the reachability graph (rfcs#111, the
+/// first C1 slice): node adjacency, SCCs, the SCC DAG, and the node-id
+/// grouping by owning path, computed ONCE per wave. Per-target work then
+/// reduces to a start-SCC lookup plus a BFS over the SCC DAG — the fast
+/// batch arm recomputed all of this on every one of N targets.
+#[derive(Debug, Clone)]
+pub struct StreamingIfdsReachabilityCondensationV0 {
+    sccs: Vec<Vec<String>>,
+    scc_by_node: BTreeMap<String, usize>,
+    scc_adjacency: BTreeMap<usize, BTreeSet<usize>>,
+    node_ids_by_path: BTreeMap<String, Vec<String>>,
+}
+
+pub fn streaming_ifds_reachability_condensation_v0(
+    hyperedges: &[UnifiedHypergraphHyperedgeV0],
+) -> StreamingIfdsReachabilityCondensationV0 {
+    let adjacency = streaming_ifds_node_adjacency(hyperedges);
+    let sccs = collect_directed_graph_sccs(&adjacency);
+    let mut scc_by_node = BTreeMap::<String, usize>::new();
+    for (index, scc) in sccs.iter().enumerate() {
+        for node_id in scc {
+            scc_by_node.insert(node_id.clone(), index);
+        }
+    }
+    let mut scc_adjacency = BTreeMap::<usize, BTreeSet<usize>>::new();
+    for (tail, heads) in &adjacency {
+        let Some(tail_scc) = scc_by_node.get(tail).copied() else {
+            continue;
+        };
+        scc_adjacency.entry(tail_scc).or_default();
+        for head in heads {
+            let Some(head_scc) = scc_by_node.get(head).copied() else {
+                continue;
+            };
+            if tail_scc != head_scc {
+                scc_adjacency.entry(tail_scc).or_default().insert(head_scc);
+            }
+        }
+    }
+    // Mirrors `streaming_ifds_node_ids_for_path` exactly: every node id from
+    // tails + heads, deduped and sorted per owning path.
+    let mut grouped = BTreeMap::<String, BTreeSet<String>>::new();
+    for edge in hyperedges {
+        for node_id in edge
+            .tail_node_ids
+            .iter()
+            .chain(std::iter::once(&edge.head_node_id))
+        {
+            if let Some(path) = streaming_ifds_node_path(node_id) {
+                grouped
+                    .entry(path.to_string())
+                    .or_default()
+                    .insert(node_id.clone());
+            }
+        }
+    }
+    StreamingIfdsReachabilityCondensationV0 {
+        sccs,
+        scc_by_node,
+        scc_adjacency,
+        node_ids_by_path: grouped
+            .into_iter()
+            .map(|(path, node_ids)| (path, node_ids.into_iter().collect()))
+            .collect(),
+    }
+}
+
+/// Per-target reachability over a prebuilt condensation. Byte-identical to
+/// [`summarize_streaming_ifds_cross_file_reachability_v0`] on the same
+/// hyperedges (gated by the parity test below).
+pub fn summarize_streaming_ifds_cross_file_reachability_with_condensation_v0(
+    target_style_path: &str,
+    condensation: &StreamingIfdsReachabilityCondensationV0,
+) -> StreamingIFDSCrossFileReachabilityReportV0 {
+    let start_node_ids = condensation
+        .node_ids_by_path
+        .get(target_style_path)
+        .cloned()
+        .unwrap_or_default();
+    let mut seen_sccs = BTreeSet::<usize>::new();
+    let mut pending_sccs = VecDeque::<usize>::new();
+    for start_node_id in &start_node_ids {
+        if let Some(scc_index) = condensation.scc_by_node.get(start_node_id).copied()
+            && seen_sccs.insert(scc_index)
+        {
+            pending_sccs.push_back(scc_index);
+        }
+    }
+    while let Some(scc) = pending_sccs.pop_front() {
+        for next_scc in condensation.scc_adjacency.get(&scc).into_iter().flatten() {
+            if seen_sccs.insert(*next_scc) {
+                pending_sccs.push_back(*next_scc);
+            }
+        }
+    }
+    let mut reachable_foreign_paths = BTreeSet::<String>::new();
+    for scc in seen_sccs {
+        let Some(node_ids) = condensation.sccs.get(scc) else {
+            continue;
+        };
+        for node_id in node_ids {
+            if let Some(path) = streaming_ifds_node_path(node_id)
+                && path != target_style_path
+            {
+                reachable_foreign_paths.insert(path.to_string());
+            }
+        }
+    }
+    let reachable_foreign_paths = reachable_foreign_paths.into_iter().collect::<Vec<_>>();
+    StreamingIFDSCrossFileReachabilityReportV0 {
+        schema_version: STREAMING_IFDS_SCHEMA_VERSION_V0,
+        product: "omena-streaming-ifds.cross-file-reachability-report",
+        layer_marker: STREAMING_IFDS_LAYER_MARKER_V0,
+        feature_gate: STREAMING_IFDS_FEATURE_GATE_V0,
+        target_style_path: target_style_path.to_string(),
+        start_node_count: start_node_ids.len(),
+        reachable_foreign_path_count: reachable_foreign_paths.len(),
+        reachable_foreign_paths,
+        analysis_report_count: start_node_ids.len(),
+        precision_parity_with_batch: true,
+        exact_default: true,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StreamingIfdsCrossFileReachabilityFastSummaryV0 {
     report: StreamingIFDSCrossFileReachabilityReportV0,
@@ -2243,6 +2367,27 @@ mod tests {
             .iter()
             .map(|fact| fact.node_id.as_str())
             .collect()
+    }
+
+    #[test]
+    fn condensation_reachability_matches_batch_summarize() {
+        // rfcs#111 C1 slice parity gate: the shared-condensation arm must be
+        // byte-identical to the per-call batch arm for every target path.
+        let hyperedges = vec![
+            hyperedge("e1", "sel|a.scss|x", "sel|b.scss|y"),
+            hyperedge("e2", "sel|b.scss|y", "sel|c.scss|z"),
+            hyperedge("e3", "sel|c.scss|z", "sel|b.scss|y"),
+            hyperedge("e4", "sel|d.scss|w", "sel|d.scss|w2"),
+        ];
+        let condensation = streaming_ifds_reachability_condensation_v0(&hyperedges);
+        for target in ["a.scss", "b.scss", "c.scss", "d.scss", "unknown.scss"] {
+            let batch = summarize_streaming_ifds_cross_file_reachability_v0(target, &hyperedges);
+            let shared = summarize_streaming_ifds_cross_file_reachability_with_condensation_v0(
+                target,
+                &condensation,
+            );
+            assert_eq!(shared, batch, "condensation arm diverged for {target}");
+        }
     }
 
     fn hyperedge(id: &str, from: &str, to: &str) -> UnifiedHypergraphHyperedgeV0 {


### PR DESCRIPTION
## What

Implements the **Tide scheduling topology** (design RFC: omenien/rfcs#111) through its M0–M4 migration milestones. Stacks on #141 (the incident fix this generalizes; design evidence: omenien/rfcs#110).

- **M0 — property harness before the code it gates**: deterministic xorshift event streams drive the kernel against an independent model — footprint validity, one-in-flight-tide-per-lane, flush-drains-all, aging-never-overrides-correctness, alarm-once-per-window, deposit idempotence, and the publication order key.
- **M1 — kernel**: `EpochLedger` (one monotone epoch + per-input-kind high-water marks; job validity consults ONLY the job's declared footprint, so a keystroke cannot stale an in-flight SIF job), `DemandSet` lanes, two-layer `SettleGate` (correctness = frontier passage, never overridable; courtesy = idleness, aging-bounded with a starvation *alarm* instead of a forced flush), generation stamps for item-boundary aborts.
- **M2 — shell wiring**: every SIF-refresh trigger becomes an idempotent demand deposit; jobs carry footprint stamps instead of revisions; the post-apply follow-up becomes a `WorkspaceRepublish` demand behind its own gate with an output cutoff (an `Eq` SIF set deposits nothing). The owed-at-quiesce flag from #141 is subsumed by the gate. Also fixes a live staleness bug: **changed diagnostics settings now deposit a workspace republish** — previously severity / deep-analysis changes left published diagnostics stale indefinitely (settings-`Eq` changes cut off).
- **M3 — off-loop IdleLane executor** (parallel-wave builds): the republish tide runs the shared-graph parallel wave against a copy-on-write snapshot on a dedicated worker, through a new abort-capable arm that checks the lane's generation watch at item boundaries; publish applies are pumped back on the loop under a per-tick chunk budget, with **disk-cache write-behind through the loop's real session** — so the next open of an unchanged workspace loads instead of recomputing. Non-parallel builds keep the loop-side per-file flush.
- **M4 — observability**: the debug-state request now reports the ledger epoch, both lanes' generation / in-flight / demand, and the starvation alarm count.

## Measurements — same 137-style-document workspace as rfcs#110/#141

| | pre-#141 | #141 | **Tide cold** | **Tide warm** |
|---|---|---|---|---|
| cold-open settle | 35+ min, non-settling | 18.5 min | **5.0 min** | **~1 min** |
| CPU shape | 1 core, loop-adjacent | 1 core, background | 4 cores × 4.3 min, off-loop | brief burst |
| hover during the round | — | 19–24 ms | **20–46 ms** | 41–47 ms |
| open doc fully converged | — | 102 s | 270 s | **6 s** |
| SIF jobs / discarded | 19 / 10 | 3 / 1 | **3 / 0** | 3 / 0 |
| `changed=true` transitions | 2 (0→10→19) | 1 (0→19) | 1 (0→19) | 0 (Eq cutoff) |
| republish rounds | 2 | 1 | **1 tide** | 1 tide (cache-served) |

Zero discards: the startup handshake jobs now stay *valid* under footprint stamps (a didOpen advances no footprint mark), where revision counters used to discard them.

## Honest behavioral deltas

1. Unopened files no longer receive early partial-SIF baseline publishes during the settle window (those came from the per-file dispatch mechanism and carried transient false positives); their first publish is the converged value when the tide applies. Open documents keep their immediate publishes.
2. On the cold path, an open document's *converged* value arrives with the tide (270 s) rather than at its slot in the old serial queue (102 s) — warm path more than repays this (6 s). Follow-up knob if wanted: per-item streaming from the wave with open-docs-first ordering.
3. The remaining cold-wave cost (137 × 7.7 s ÷ 4 cores) is the C1 unwired-incremental floor (rfcs#110 §9.1); Tide is a beneficiary of that work, not a precondition.

## Tests

- 186 lib + 11 bin, single-threaded green (the 2 known parallel-run flakes pre-exist on master, see #141).
- New: 6 kernel property tests (M0), 2 executor round-trip/disowned-tide tests, the warmup-wave baseline test now asserts one-tide-per-settle-window directly.
- Feature-combo builds verified: default, `--no-default-features`, salsa-only.
- Live protocol (rfcs#110 §10) re-run: one `sif-job-prepared gen=3 epoch=16 docs=149`, one `changed=true 0→19`, one `republish-tide prepared gen=1 targets=137`, zero discards, settle confirmed on both cold and warm runs.

## Commits

1. `feat(tide): add scheduling kernel with M0 property harness`
2. `feat(tide): wire the kernel into the shell - M2 deposits, gates, footprint validity`
3. `feat(tide): off-loop IdleLane executor for the workspace republish - M3`
4. `feat(tide): expose ledger and lane state through the debug snapshot - M4 observability`
