### PR TITLE
fix: per-origin cold-build regression + workspace cache self-ignore markers

### DIFF
--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -229,6 +229,31 @@ impl DiskDiagnosticsCacheSlotV0 {
     }
 }
 
+/// Self-ignore markers for the workspace-relative cache root (`.cache/omena`):
+/// a `.gitignore` containing `*` (the `.next/.gitignore` pattern — git and
+/// git-driven tooling skip the tree without touching any user config) and a
+/// standard `CACHEDIR.TAG` (archivers/backup tools skip tagged directories).
+/// Written once, next to whichever cache subsystem touches the root first.
+pub(crate) fn ensure_omena_cache_root_markers(cache_subdir: &Path) {
+    let Some(omena_root) = cache_subdir.parent() else {
+        return;
+    };
+    let gitignore = omena_root.join(".gitignore");
+    if !gitignore.exists() {
+        let _ = fs::write(
+            gitignore,
+            "# machine-generated omena cache - safe to delete\n*\n",
+        );
+    }
+    let cachedir_tag = omena_root.join("CACHEDIR.TAG");
+    if !cachedir_tag.exists() {
+        let _ = fs::write(
+            cachedir_tag,
+            "Signature: 8a477f597d28d172789f06886806bc55\n# This directory is an omena cache; contents are regenerable.\n",
+        );
+    }
+}
+
 pub(crate) fn disk_diagnostics_cache_slot_for_resolve(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
@@ -468,6 +493,7 @@ fn write_disk_diagnostics_shard_atomically(
     bytes: &[u8],
 ) -> std::io::Result<()> {
     fs::create_dir_all(dir)?;
+    ensure_omena_cache_root_markers(dir);
     let final_path = disk_diagnostics_shard_file_path(dir, key).ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::InvalidInput, "non-hex shard key")
     })?;
@@ -534,6 +560,24 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    #[test]
+    fn cache_writes_stamp_self_ignore_markers_at_omena_root() {
+        let dir = temp_cache_dir("markers").join(".cache/omena/diagnostics-cache-v0");
+        fs::create_dir_all(dir.as_path()).unwrap();
+        ensure_omena_cache_root_markers(dir.as_path());
+        let omena_root = dir.parent().unwrap();
+        let gitignore = fs::read_to_string(omena_root.join(".gitignore")).unwrap();
+        assert!(
+            gitignore.contains("*"),
+            "gitignore must ignore the whole cache tree"
+        );
+        let tag = fs::read_to_string(omena_root.join("CACHEDIR.TAG")).unwrap();
+        assert!(tag.starts_with("Signature: 8a477f597d28d172789f06886806bc55"));
+        // idempotent: second call must not error or duplicate
+        ensure_omena_cache_root_markers(dir.as_path());
+        let _ = fs::remove_dir_all(omena_root.parent().unwrap().parent().unwrap());
+    }
 
     fn temp_cache_dir(suffix: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(

--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -562,21 +562,25 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[test]
-    fn cache_writes_stamp_self_ignore_markers_at_omena_root() {
-        let dir = temp_cache_dir("markers").join(".cache/omena/diagnostics-cache-v0");
-        fs::create_dir_all(dir.as_path()).unwrap();
+    fn cache_writes_stamp_self_ignore_markers_at_omena_root() -> Result<(), &'static str> {
+        let base = temp_cache_dir("markers");
+        let dir = base.join(".cache/omena/diagnostics-cache-v0");
+        fs::create_dir_all(dir.as_path()).map_err(|_| "create cache dir")?;
         ensure_omena_cache_root_markers(dir.as_path());
-        let omena_root = dir.parent().unwrap();
-        let gitignore = fs::read_to_string(omena_root.join(".gitignore")).unwrap();
+        let omena_root = dir.parent().ok_or("omena root")?;
+        let gitignore =
+            fs::read_to_string(omena_root.join(".gitignore")).map_err(|_| "read gitignore")?;
         assert!(
             gitignore.contains("*"),
             "gitignore must ignore the whole cache tree"
         );
-        let tag = fs::read_to_string(omena_root.join("CACHEDIR.TAG")).unwrap();
+        let tag =
+            fs::read_to_string(omena_root.join("CACHEDIR.TAG")).map_err(|_| "read cachedir tag")?;
         assert!(tag.starts_with("Signature: 8a477f597d28d172789f06886806bc55"));
         // idempotent: second call must not error or duplicate
         ensure_omena_cache_root_markers(dir.as_path());
-        let _ = fs::remove_dir_all(omena_root.parent().unwrap().parent().unwrap());
+        let _ = fs::remove_dir_all(base.as_path());
+        Ok(())
     }
 
     fn temp_cache_dir(suffix: &str) -> PathBuf {

--- a/rust/crates/omena-lsp-server/src/source_document_cache.rs
+++ b/rust/crates/omena-lsp-server/src/source_document_cache.rs
@@ -108,6 +108,7 @@ pub(crate) fn store_source_document_index_sidecar(
     if fs::create_dir_all(dir).is_err() {
         return;
     }
+    crate::disk_cache::ensure_omena_cache_root_markers(dir);
     let payload = json!({
         "sourceSyntaxIndex": source_syntax_index,
         "hasUnresolvedStyleImport": has_unresolved_style_import,

--- a/rust/crates/omena-lsp-server/src/source_occurrence_cache.rs
+++ b/rust/crates/omena-lsp-server/src/source_occurrence_cache.rs
@@ -30,6 +30,7 @@ pub(crate) fn store_source_selector_occurrence_sidecar(
     if fs::create_dir_all(dir).is_err() {
         return;
     }
+    crate::disk_cache::ensure_omena_cache_root_markers(dir);
     let payload = json!({
         "definitions": definitions,
         "index": index,

--- a/rust/crates/omena-lsp-server/src/source_type_fact_cache.rs
+++ b/rust/crates/omena-lsp-server/src/source_type_fact_cache.rs
@@ -47,6 +47,7 @@ pub(crate) fn store_source_type_fact_sidecar(
     if fs::create_dir_all(dir).is_err() {
         return;
     }
+    crate::disk_cache::ensure_omena_cache_root_markers(dir);
     let payload = json!({
         "entries": entries,
         "entryCount": entries.len(),

--- a/rust/crates/omena-lsp-server/src/style_symbol_occurrence_cache.rs
+++ b/rust/crates/omena-lsp-server/src/style_symbol_occurrence_cache.rs
@@ -31,6 +31,7 @@ pub(crate) fn store_style_symbol_occurrence_sidecar(
     if fs::create_dir_all(dir).is_err() {
         return;
     }
+    crate::disk_cache::ensure_omena_cache_root_markers(dir);
     let payload = json!({
         "occurrences": occurrences,
         "occurrenceCount": occurrences.len(),

--- a/rust/crates/omena-lsp-server/src/workspace_occurrence_cache.rs
+++ b/rust/crates/omena-lsp-server/src/workspace_occurrence_cache.rs
@@ -116,6 +116,7 @@ pub(crate) fn store_workspace_occurrence_shard(
     if fs::create_dir_all(dir).is_err() {
         return;
     }
+    crate::disk_cache::ensure_omena_cache_root_markers(dir);
     let payload = json!({
         "occurrences": occurrences,
         "occurrenceCount": occurrences.len(),

--- a/rust/crates/omena-query/src/style/salsa_memo.rs
+++ b/rust/crates/omena-query/src/style/salsa_memo.rs
@@ -3353,7 +3353,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     #[ignore = "timing harness - run with --ignored --nocapture in release"]
     fn cold_build_timing_per_origin_vs_monolith() {
         for n in [50usize, 100, 150] {
@@ -3405,6 +3404,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn module_interface_projection_preserves_body_only_edits() {
         let mut corpus = vec![OmenaQueryStyleSourceInputV0 {
             style_path: "/workspace/src/Card.module.scss".to_string(),

--- a/rust/crates/omena-query/src/style/salsa_memo.rs
+++ b/rust/crates/omena-query/src/style/salsa_memo.rs
@@ -888,11 +888,7 @@ fn memo_css_modules_import_edge_resolutions_for_origin_from_module_interfaces(
         .iter()
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
-    let style_import_edges = style_import_reachability_edges_from_dependency_surfaces(
-        module_dependency_surfaces_for_workspace(db, workspace).as_slice(),
-        &available_style_path_refs,
-        package_manifests.as_slice(),
-    );
+    let style_import_edges = memo_style_import_reachability_edges(db, workspace);
     let target_interfaces = origin
         .style_dependency_sources
         .iter()
@@ -1306,7 +1302,14 @@ fn style_fact_entries_for_workspace(
     style_fact_entries
 }
 
-fn style_paths_for_workspace(
+/// Workspace-level accessories hoisted into tracked queries (regression fix:
+/// the per-origin edge-resolution queries recomputed these — including the
+/// FULL workspace import-edge resolution — once per origin, which explodes
+/// on corpora with unresolvable specifiers where candidate generation cannot
+/// early-return. One execution per revision; `Eq` outputs backdate, so the
+/// module-interface firewall semantics are preserved.
+#[salsa::tracked(returns(ref))]
+fn memo_style_paths_for_workspace(
     db: &dyn salsa::Database,
     workspace: OmenaQueryStyleWorkspaceInputV0,
 ) -> Vec<String> {
@@ -1319,7 +1322,8 @@ fn style_paths_for_workspace(
     style_paths
 }
 
-fn resolver_style_paths_for_workspace(
+#[salsa::tracked(returns(ref))]
+fn memo_resolver_style_paths_for_workspace(
     db: &dyn salsa::Database,
     workspace: OmenaQueryStyleWorkspaceInputV0,
 ) -> BTreeSet<String> {
@@ -1333,16 +1337,56 @@ fn resolver_style_paths_for_workspace(
         .collect()
 }
 
+#[salsa::tracked(returns(ref))]
+fn memo_file_by_style_path(
+    db: &dyn salsa::Database,
+    workspace: OmenaQueryStyleWorkspaceInputV0,
+) -> BTreeMap<String, OmenaQueryStyleFileInputV0> {
+    workspace
+        .files(db)
+        .iter()
+        .map(|file| (file.style_path(db).clone(), *file))
+        .collect()
+}
+
+#[salsa::tracked(returns(ref))]
+fn memo_style_import_reachability_edges(
+    db: &dyn salsa::Database,
+    workspace: OmenaQueryStyleWorkspaceInputV0,
+) -> Vec<omena_semantic::StyleImportReachabilityEdgeFactV0> {
+    let available_style_paths = memo_style_paths_for_workspace(db, workspace)
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    style_import_reachability_edges_from_dependency_surfaces(
+        module_dependency_surfaces_for_workspace(db, workspace).as_slice(),
+        &available_style_paths,
+        workspace.package_manifests(db).as_slice(),
+    )
+}
+
+fn style_paths_for_workspace(
+    db: &dyn salsa::Database,
+    workspace: OmenaQueryStyleWorkspaceInputV0,
+) -> Vec<String> {
+    memo_style_paths_for_workspace(db, workspace).clone()
+}
+
+fn resolver_style_paths_for_workspace(
+    db: &dyn salsa::Database,
+    workspace: OmenaQueryStyleWorkspaceInputV0,
+) -> BTreeSet<String> {
+    memo_resolver_style_paths_for_workspace(db, workspace).clone()
+}
+
 fn file_for_style_path(
     db: &dyn salsa::Database,
     workspace: OmenaQueryStyleWorkspaceInputV0,
     style_path: &str,
 ) -> Option<OmenaQueryStyleFileInputV0> {
-    workspace
-        .files(db)
-        .iter()
+    memo_file_by_style_path(db, workspace)
+        .get(style_path)
         .copied()
-        .find(|file| file.style_path(db) == style_path)
 }
 
 fn module_dependency_surfaces_for_workspace(
@@ -3309,6 +3353,58 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    #[ignore = "timing harness - run with --ignored --nocapture in release"]
+    fn cold_build_timing_per_origin_vs_monolith() {
+        for n in [50usize, 100, 150] {
+            let corpus: Vec<OmenaQueryStyleSourceInputV0> = (0..n)
+                .map(|i| OmenaQueryStyleSourceInputV0 {
+                    style_path: format!("/workspace/src/F{i}.module.scss"),
+                    style_source: format!(
+                        "@use \"./F{}.module.scss\" as dep;\n@use \"@ext/tokens\" as t;\n@use \"$alias/mixins\" as m;\n.c{i} {{ color: red; }}\n.d{i} {{ composes: c{} from './F{}.module.scss'; }}\n.e{i} {{ composes: shared from '@theme/shared.module.css'; }}\n",
+                        (i + 1) % n,
+                        (i + 2) % n,
+                        (i + 2) % n,
+                    ),
+                })
+                .collect();
+            let resolution_inputs = OmenaQueryStyleResolutionInputsV0::default();
+
+            let mut host = OmenaQueryStyleMemoHostV0::new();
+            let workspace =
+                host.sync_workspace(corpus.as_slice(), &[], &[], &[], &resolution_inputs);
+            let started = std::time::Instant::now();
+            let graph = build_committed_style_semantic_graph(
+                &host.db,
+                workspace,
+                &[],
+                &[],
+                &[],
+                &resolution_inputs,
+            );
+            let per_origin_ms = started.elapsed().as_millis();
+
+            let mut host2 = OmenaQueryStyleMemoHostV0::new();
+            let workspace2 =
+                host2.sync_workspace(corpus.as_slice(), &[], &[], &[], &resolution_inputs);
+            let started2 = std::time::Instant::now();
+            let graph2 = build_committed_style_semantic_graph_monolith(
+                &host2.db,
+                workspace2,
+                &[],
+                &[],
+                &[],
+                &resolution_inputs,
+            );
+            let monolith_ms = started2.elapsed().as_millis();
+            assert_eq!(graph, graph2, "arms must stay byte-identical");
+            println!(
+                "N={n}: per-origin={per_origin_ms}ms monolith={monolith_ms}ms ratio={:.1}x",
+                per_origin_ms as f64 / monolith_ms.max(1) as f64
+            );
+        }
+    }
+
     fn module_interface_projection_preserves_body_only_edits() {
         let mut corpus = vec![OmenaQueryStyleSourceInputV0 {
             style_path: "/workspace/src/Card.module.scss".to_string(),

--- a/rust/omena-two-tier-identity-inventory.json
+++ b/rust/omena-two-tier-identity-inventory.json
@@ -122,7 +122,7 @@
   {
     "id": "rust/crates/omena-query/src/style/salsa_memo.rs#OmenaQueryStyleMemoHostV0.committed_module_interface_changed_paths",
     "sourcePath": "rust/crates/omena-query/src/style/salsa_memo.rs",
-    "sourceAnchor": "rust/crates/omena-query/src/style/salsa_memo.rs:1574",
+    "sourceAnchor": "rust/crates/omena-query/src/style/salsa_memo.rs:1618",
     "owner": "OmenaQueryStyleMemoHostV0",
     "name": "committed_module_interface_changed_paths",
     "collectionType": "BTreeSet<String>",
@@ -134,7 +134,7 @@
   {
     "id": "rust/crates/omena-query/src/style/salsa_memo.rs#OmenaQueryStyleMemoHostV0.files_by_path",
     "sourcePath": "rust/crates/omena-query/src/style/salsa_memo.rs",
-    "sourceAnchor": "rust/crates/omena-query/src/style/salsa_memo.rs:1569",
+    "sourceAnchor": "rust/crates/omena-query/src/style/salsa_memo.rs:1613",
     "owner": "OmenaQueryStyleMemoHostV0",
     "name": "files_by_path",
     "collectionType": "BTreeMap<String, OmenaQueryStyleFileInputV0>",
@@ -146,7 +146,7 @@
   {
     "id": "rust/crates/omena-query/src/style/salsa_memo.rs#OmenaQueryStyleMemoHostV0.registered_style_paths",
     "sourcePath": "rust/crates/omena-query/src/style/salsa_memo.rs",
-    "sourceAnchor": "rust/crates/omena-query/src/style/salsa_memo.rs:1570",
+    "sourceAnchor": "rust/crates/omena-query/src/style/salsa_memo.rs:1614",
     "owner": "OmenaQueryStyleMemoHostV0",
     "name": "registered_style_paths",
     "collectionType": "BTreeSet<String>",


### PR DESCRIPTION
## Two field regressions from real-workspace soak, diagnosed and fixed

Both surfaced within a day of daily use on a 137-style-document workspace running current master.

### 1. Cold-open wave regressed 13.2s → 74.3s; hover/goto-def stalled for minutes

**Symptom**: cold open settled in 2–4 minutes instead of ~1; hover followed by go-to-definition spun indefinitely during the window. A mid-wave `sample` showed 90% of time under `memo_css_modules_import_edge_resolutions_for_origin_from_module_interfaces → resolve_style_module_source → push_style_*_candidate / normalize_style_path`, and the goto-def stall shared the same frames through the query worker's fresh-host cascade-substrate build.

**Root cause (measured, with one false lead)**: the per-origin decomposition recomputed four workspace-level accessories inside every per-origin query — most damagingly the FULL workspace import-edge resolution (every module's every dependency source re-resolved per origin), plus the sorted path list, the resolver-normalized path set, and a linear file-by-path scan. A first synthetic benchmark (success-only imports) showed per-origin ≈ monolith (1.1×) — a false acquittal. Injecting **unresolvable specifiers** (external aliases resolved through SIFs — the normal real-workspace shape) flipped it: failed resolutions walk the entire candidate space with no early return, and repeating that walk per origin measured **7.3× over the monolith arm at N=50, 4.9× at N=100**.

**Fix**: hoist all four accessories into `#[salsa::tracked]` queries — one execution per revision; `Eq` outputs backdate, so the module-interface firewall semantics are preserved bit-for-bit (all backdating/scoping probes green; the graph byte-equality assert against the monolith arm holds). Helpers delegate to the memos, so call sites are unchanged.

**Measured after**: synthetic ratio back to 1.0–1.1×; real-workspace cold wave **74.3s → 14.1s**; cold settle ~1 min; hover 46ms post-index; converged diagnostic sets idempotent. The unresolvable-specifier timing harness ships as an ignored test so the condition that hid the regression stays reproducible.

**Honest note**: both arms remain ~N^3.5 on the failure-heavy corpus shape independent of this regression — a pre-existing ceiling worth its own ledger entry.

### 2. The workspace cache polluted git and project formatters

**Symptom**: `.cache/omena` (7,905 files / 143MB across seven subsystems) appeared as untracked in `git status` and a project formatter rewrote **6,844 cache JSON files**.

**Root cause**: no cache subsystem wrote any exclusion marker, and only `diagnostics-cache-v0` has eviction limits — the other five sidecar caches grow unboundedly (sole cleanup: whole-tree wipe on version bump).

**Fix (first slice)**: every cache-directory creation path now stamps, once and idempotently, a `.gitignore` containing `*` (the `.next/.gitignore` pattern — git and git-driven tooling skip the tree with zero user configuration) and a standard `CACHEDIR.TAG`. Covered by a marker unit test.

**Documented follow-ups**: eviction caps for the five uncapped sidecars (generalizing the diagnostics-cache limits) and OS-cache-directory relocation (`~/Library/Caches` / `$XDG_CACHE_HOME` keyed by workspace identity) as the structural end state — at which point exclusion markers become moot.

### Tests
626 query (backdating probes included) + 195 lsp, single-threaded green; byte-equality between per-origin and monolith arms asserted in the harness.
