### PR TITLE
feat(disk-cache): Tidepool - verifying-trace diagnostics cache (stage 2)

### DIFF
--- a/rust/crates/omena-cross-file-summary/src/lib.rs
+++ b/rust/crates/omena-cross-file-summary/src/lib.rs
@@ -179,6 +179,37 @@ pub fn reverse_dependency_closure_v0(
     visited
 }
 
+/// The declared read-set of ONE style target's workspace diagnostics, as a
+/// path set over the summary's edge graph: the target itself, its FORWARD
+/// closure (modules whose contents the target's resolution, token, cascade,
+/// replica-ensemble, and reachability arms read), and its DIRECT reverse
+/// neighbors (style and source files whose references decide the target's
+/// usage-derived diagnostics). This is the verifying-trace manifest for the
+/// disk diagnostics cache: completeness is oracle-gated in the LSP crate
+/// (a manifest-verified hit must be byte-identical to a fresh compute), so
+/// any diagnostics arm that grows a wider read window fails the oracle
+/// instead of silently serving stale shards.
+pub fn diagnostics_read_set_for_target_v0(
+    index: &ReverseDependencyIndexV0,
+    target_path: &str,
+) -> BTreeSet<String> {
+    let mut read_set = BTreeSet::from([target_path.to_string()]);
+    let mut queue = VecDeque::from([target_path.to_string()]);
+    while let Some(path) = queue.pop_front() {
+        if let Some(targets) = index.edges_by_from.get(path.as_str()) {
+            for next in targets {
+                if read_set.insert(next.clone()) {
+                    queue.push_back(next.clone());
+                }
+            }
+        }
+    }
+    if let Some(dependents) = index.rev.get(target_path) {
+        read_set.extend(dependents.iter().cloned());
+    }
+    read_set
+}
+
 fn reverse_dependency_groups_by_from_path(
     edges: &[OmenaQueryCrossFileSummaryEdgeV0],
 ) -> BTreeMap<String, BTreeSet<String>> {

--- a/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
+++ b/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
@@ -1529,7 +1529,15 @@ mod tests {
                 "params": {},
             }),
         )?;
-        for request_index in 0..20 {
+        // Condition-based wait, not a fixed request count: the background
+        // scan is time-budgeted per tick, so its wall-clock depends on
+        // machine load — a fixed 20-poll window flakes on slow machines.
+        // Poll until the shared sink shows a reference into the late source
+        // or a generous deadline expires; the assertion below stays the
+        // arbiter either way.
+        let poll_deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let mut request_index = 0u64;
+        loop {
             thread::sleep(Duration::from_millis(75));
             write_lsp_frame(
                 &mut client_stream,
@@ -1551,6 +1559,19 @@ mod tests {
                     },
                 }),
             )?;
+            request_index += 1;
+            thread::sleep(Duration::from_millis(75));
+            let observed = {
+                let output = sink
+                    .0
+                    .lock()
+                    .map_err(|_| "shared writer poisoned".to_string())?
+                    .clone();
+                String::from_utf8_lossy(output.as_slice()).contains(late_source_uri.as_str())
+            };
+            if observed || std::time::Instant::now() >= poll_deadline {
+                break;
+            }
         }
         write_lsp_frame(
             &mut client_stream,
@@ -1585,7 +1606,7 @@ mod tests {
                 message
                     .get("id")
                     .and_then(Value::as_u64)
-                    .is_some_and(|id| (20..40).contains(&id))
+                    .is_some_and(|id| (20..100).contains(&id))
                     && message
                         .pointer("/result")
                         .and_then(Value::as_array)

--- a/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
+++ b/rust/crates/omena-lsp-server/src/bin/omena-lsp-server.rs
@@ -524,7 +524,14 @@ fn drain_and_pump_tide_republish<W: Write + Send + 'static>(
                 }
                 applied = applied.saturating_add(1);
             }
-            if active.items.is_empty() {
+            // Completion requires BOTH the final chunk and a drained queue:
+            // a streaming wave trickles items across loop turns, and
+            // completing on a momentarily-empty queue would clear the
+            // lane's in-flight tide mid-stream — turning every subsequent
+            // window reopen into a no-op (no disown, no abort, no demand
+            // carry-over) while the wave keeps publishing against the
+            // pre-reopen snapshot.
+            if active.final_chunk_seen && active.items.is_empty() {
                 completed = Some((
                     active.generation,
                     std::mem::take(&mut active.uncovered_uris),
@@ -801,6 +808,140 @@ fn lock_coalescer(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression pin for the pump completion gate: a streaming wave
+    /// trickles items across loop turns, so a momentarily-empty apply queue
+    /// BEFORE the final chunk must NOT complete the tide — completing early
+    /// clears the lane's in-flight state and turns every subsequent window
+    /// reopen into a no-op (no disown, no abort, no demand carry-over).
+    #[cfg(all(
+        feature = "parallel-style-diagnostics",
+        feature = "salsa-style-diagnostics"
+    ))]
+    #[test]
+    fn pump_completes_only_after_the_final_chunk() -> Result<(), String> {
+        let mut state = LspShellState::default();
+        omena_lsp_server::enable_deferred_external_sif_refresh(&mut state);
+        omena_lsp_server::handle_lsp_message(
+            &mut state,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": "file:///workspace/src/Pump.module.scss",
+                        "languageId": "scss",
+                        "version": 1,
+                        "text": ".pump { color: red; }",
+                    },
+                },
+            }),
+        );
+        omena_lsp_server::handle_lsp_message(
+            &mut state,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": "file:///workspace/src/Other.module.scss",
+                        "languageId": "scss",
+                        "version": 1,
+                        "text": ".other { color: blue; }",
+                    },
+                },
+            }),
+        );
+        let sif_job = prepare_deferred_external_sif_refresh_job(&mut state)
+            .ok_or("startup SIF demand must flush")?;
+        let sif_result = omena_lsp_server::collect_deferred_external_sif_refresh(sif_job);
+        apply_deferred_external_sif_refresh_result(&mut state, sif_result);
+        // A diagnostics-settings change deposits a workspace republish.
+        omena_lsp_server::handle_lsp_message(
+            &mut state,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "workspace/didChangeConfiguration",
+                "params": {
+                    "settings": {
+                        "omena": {
+                            "diagnostics": { "severity": "hint" },
+                        },
+                    },
+                },
+            }),
+        );
+        let job = prepare_tide_workspace_republish_job(&mut state, true)
+            .ok_or("republish demand must flush")?;
+        let generation = job.generation;
+        assert!(state.tide_republish_lane_in_flight());
+
+        let (result_sender, result_receiver) =
+            mpsc::sync_channel::<TideWorkspaceRepublishResultV0>(8);
+        let writer = Arc::new(Mutex::new(SharedBufferWriter::default()));
+        let coalescer = Arc::new(Mutex::new(ScheduledOutputCoalescer::default()));
+        let mut delayed_outputs: Vec<JoinHandle<Result<(), String>>> = Vec::new();
+        let (diagnostics_sender, _diagnostics_receiver) =
+            mpsc::sync_channel::<DeferredDiagnosticsWorkV0>(8);
+        let mut in_flight = 1usize;
+        let mut pending: Option<PendingTideRepublishApplyV0> = None;
+
+        // A mid-stream chunk with a drained queue must NOT complete the tide.
+        result_sender
+            .send(TideWorkspaceRepublishResultV0 {
+                generation,
+                items: Vec::new(),
+                uncovered_uris: Vec::new(),
+                final_chunk: false,
+            })
+            .map_err(|error| error.to_string())?;
+        drain_and_pump_tide_republish(
+            &mut state,
+            &result_receiver,
+            &mut in_flight,
+            &mut pending,
+            TideRepublishPumpIo {
+                writer: &writer,
+                coalescer: &coalescer,
+                delayed_outputs: &mut delayed_outputs,
+                diagnostics_sender: &diagnostics_sender,
+            },
+        )
+        .map_err(|error| error.to_string())?;
+        assert!(
+            state.tide_republish_lane_in_flight(),
+            "an empty apply queue before the final chunk must not complete the tide"
+        );
+
+        // The final chunk drains the stream and completes the tide.
+        result_sender
+            .send(TideWorkspaceRepublishResultV0 {
+                generation,
+                items: Vec::new(),
+                uncovered_uris: Vec::new(),
+                final_chunk: true,
+            })
+            .map_err(|error| error.to_string())?;
+        drain_and_pump_tide_republish(
+            &mut state,
+            &result_receiver,
+            &mut in_flight,
+            &mut pending,
+            TideRepublishPumpIo {
+                writer: &writer,
+                coalescer: &coalescer,
+                delayed_outputs: &mut delayed_outputs,
+                diagnostics_sender: &diagnostics_sender,
+            },
+        )
+        .map_err(|error| error.to_string())?;
+        assert!(
+            !state.tide_republish_lane_in_flight(),
+            "the final chunk with a drained queue completes the tide"
+        );
+        assert_eq!(in_flight, 0);
+        Ok(())
+    }
     use omena_lsp_server::prepare_background_workspace_index_job;
     #[cfg(feature = "salsa-style-diagnostics")]
     use omena_query::OmenaQueryExternalSifInputV0;

--- a/rust/crates/omena-lsp-server/src/boundary.rs
+++ b/rust/crates/omena-lsp-server/src/boundary.rs
@@ -219,7 +219,7 @@ pub fn lsp_trust_boundary_contract() -> LspTrustBoundaryV0 {
             "transparencyLogClient",
             "socketNetworkIo",
         ],
-        disk_write_surfaces: vec!["<workspaceFolder>/.cache/omena/diagnostics-cache-v1"],
+        disk_write_surfaces: vec!["<workspaceFolder>/.cache/omena/**"],
     }
 }
 

--- a/rust/crates/omena-lsp-server/src/boundary.rs
+++ b/rust/crates/omena-lsp-server/src/boundary.rs
@@ -219,7 +219,7 @@ pub fn lsp_trust_boundary_contract() -> LspTrustBoundaryV0 {
             "transparencyLogClient",
             "socketNetworkIo",
         ],
-        disk_write_surfaces: vec!["<workspaceFolder>/.cache/omena/diagnostics-cache-v0"],
+        disk_write_surfaces: vec!["<workspaceFolder>/.cache/omena/diagnostics-cache-v1"],
     }
 }
 

--- a/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
@@ -42,15 +42,10 @@ pub struct LspDiagnosticsFollowUpEffectsV0 {
 pub fn external_sif_refresh_follow_up_diagnostics_effects(
     state: &mut LspShellState,
 ) -> LspDiagnosticsFollowUpEffectsV0 {
-    let uris = state
-        .documents
-        .values()
-        .filter(|document| {
-            document.origin == LspDocumentOrigin::Local
-                && is_style_document_uri(document.uri.as_str())
-        })
-        .map(|document| document.uri.clone())
-        .collect::<Vec<_>>();
+    // The reference arm for runtime-loop probes and tests: full-workspace
+    // coverage through the SAME target resolution the demand-shaped flush
+    // uses, so the two can never drift apart.
+    let uris = tide_republish_target_uris(state, &TideRepublishDemandV0::All);
     if uris.is_empty() {
         return LspDiagnosticsFollowUpEffectsV0::default();
     }

--- a/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_follow_up.rs
@@ -1,8 +1,9 @@
 use crate::diagnostics_scheduler;
 use crate::lsp_output::{LspDeferredDiagnosticsDispatchV0, ScheduledLspOutput};
 use crate::protocol::is_style_document_uri;
-use crate::tide::{TideGateInputsV0, TideLaneConfigV0};
+use crate::tide::{TideGateInputsV0, TideLaneConfigV0, TideRepublishDemandV0};
 use crate::{LspDocumentOrigin, LspExternalSifRefreshResultV0, LspShellState};
+use std::collections::BTreeSet;
 
 /// The workspace-republish lane: the M3 executor passes real idleness for
 /// the courtesy layer; aging (~10s at the 5ms tick) overrides courtesy so a
@@ -87,10 +88,74 @@ pub(crate) fn workspace_republish_frontier_passed(state: &LspShellState) -> bool
         && state.workspace_index_pending_file_count == 0
 }
 
+/// Resolve a flushed republish demand into concrete target uris — open
+/// documents first (the user is looking at them), then the rest in
+/// canonical order. `All` covers every admitted local style document;
+/// `Cone(seeds)` covers the seeds plus their reverse-dependency closure
+/// against the committed graph AT FLUSH TIME. A cone that cannot be
+/// resolved (no committed scope yet) widens to the workspace — never the
+/// other direction.
+pub(crate) fn tide_republish_target_uris(
+    state: &LspShellState,
+    demand: &TideRepublishDemandV0,
+) -> Vec<String> {
+    let cone = match demand {
+        TideRepublishDemandV0::None => return Vec::new(),
+        TideRepublishDemandV0::All => None,
+        TideRepublishDemandV0::Cone(seeds) => match republish_cone_paths(state, seeds) {
+            Some(cone) => Some(cone),
+            None => {
+                crate::loop_trace!(
+                    "republish-cone widened to all: {} seeds, no committed scope",
+                    seeds.len()
+                );
+                None
+            }
+        },
+    };
+    let mut open = Vec::new();
+    let mut unopened = Vec::new();
+    for document in state.documents.values() {
+        if document.origin != LspDocumentOrigin::Local
+            || !is_style_document_uri(document.uri.as_str())
+        {
+            continue;
+        }
+        if let Some(cone) = cone.as_ref()
+            && !diagnostics_scheduler::file_uri_set_contains_equivalent(cone, document.uri.as_str())
+        {
+            continue;
+        }
+        if state.has_open_document_uri(document.uri.as_str()) {
+            open.push(document.uri.clone());
+        } else {
+            unopened.push(document.uri.clone());
+        }
+    }
+    open.extend(unopened);
+    open
+}
+
+/// The seeds' reverse-dependency closure (seeds included) over the
+/// committed cross-file summary, or `None` when no committed scope exists.
+fn republish_cone_paths(
+    state: &LspShellState,
+    seeds: &BTreeSet<String>,
+) -> Option<BTreeSet<String>> {
+    let representative = seeds.iter().next()?;
+    let scope =
+        diagnostics_scheduler::reverse_dependency_scope_for_style_change(state, representative)?;
+    let mut cone =
+        diagnostics_scheduler::reverse_dependency_closure_for_lsp_paths(&scope.index, seeds);
+    cone.extend(seeds.iter().cloned());
+    Some(cone)
+}
+
 /// Evaluate the workspace-republish settle gate; on flush, run the follow-up
-/// executor. M2 keeps the per-file deferred executor verbatim and completes
-/// the tide at flush time — the executor swap to the off-loop generation-
-/// checked wave is exclusively M3 (rfcs#111 §12).
+/// executor over the flushed demand's targets. M2 keeps the per-file
+/// deferred executor verbatim and completes the tide at flush time — the
+/// executor swap to the off-loop generation-checked wave is exclusively M3
+/// (rfcs#111 §12).
 pub fn tide_workspace_republish_flush_effects(
     state: &mut LspShellState,
 ) -> LspDiagnosticsFollowUpEffectsV0 {
@@ -105,7 +170,25 @@ pub fn tide_workspace_republish_flush_effects(
     else {
         return LspDiagnosticsFollowUpEffectsV0::default();
     };
-    let effects = external_sif_refresh_follow_up_diagnostics_effects(state);
+    let uris = tide_republish_target_uris(state, &flush.demand);
+    let effects = if uris.is_empty() {
+        LspDiagnosticsFollowUpEffectsV0::default()
+    } else {
+        #[cfg(test)]
+        warmup_wave_count_probe::record();
+        crate::loop_trace!(
+            "sif-follow-up fired for {} style docs (deferred)",
+            uris.len()
+        );
+        let effects = diagnostics_scheduler::run_diagnostics_schedule_effects(
+            state,
+            diagnostics_scheduler::DiagnosticsScheduleEvent::WatchedFiles { uris },
+        );
+        LspDiagnosticsFollowUpEffectsV0 {
+            outputs: effects.outputs,
+            deferred_diagnostics: effects.deferred_diagnostics,
+        }
+    };
     state.tide_republish_lane.tide_completed(flush.generation);
     effects
 }

--- a/rust/crates/omena-lsp-server/src/diagnostics_scheduler.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_scheduler.rs
@@ -575,10 +575,12 @@ pub(crate) fn reverse_dependency_scope_for_style_change(
         return None;
     }
 
+    let ledger_epoch = state.tide_ledger.epoch();
     let mut memo_slot = state.reverse_dependency_index_memo.borrow_mut();
     let memo = memo_slot.get_or_insert_with(|| crate::state::LspReverseDependencyIndexMemo {
         revision,
         summary_hash: summary.summary_hash.clone(),
+        ledger_epoch,
         index: reverse_dependency_index_from_edges_v0(summary.edges.as_slice()),
     });
     if memo.revision != revision || memo.summary_hash != summary.summary_hash {
@@ -586,6 +588,7 @@ pub(crate) fn reverse_dependency_scope_for_style_change(
         memo.revision = revision;
         memo.summary_hash = summary.summary_hash.clone();
     }
+    memo.ledger_epoch = memo.ledger_epoch.max(ledger_epoch);
     Some(SourceRepublishDependencyScopeV0 {
         index: memo.index.clone(),
         changed_module_interface_paths,

--- a/rust/crates/omena-lsp-server/src/diagnostics_scheduler.rs
+++ b/rust/crates/omena-lsp-server/src/diagnostics_scheduler.rs
@@ -512,7 +512,7 @@ fn scoped_source_republish_uris_for_style_change(
         .collect()
 }
 
-fn reverse_dependency_closure_for_lsp_paths(
+pub(crate) fn reverse_dependency_closure_for_lsp_paths(
     index: &omena_query::ReverseDependencyIndexV0,
     seeds: &BTreeSet<String>,
 ) -> BTreeSet<String> {
@@ -548,7 +548,7 @@ fn file_uri_identity_aliases(uri: &str) -> BTreeSet<String> {
     aliases
 }
 
-fn file_uri_set_contains_equivalent(values: &BTreeSet<String>, uri: &str) -> bool {
+pub(crate) fn file_uri_set_contains_equivalent(values: &BTreeSet<String>, uri: &str) -> bool {
     values.contains(uri) || values.iter().any(|value| file_uri_equivalent(value, uri))
 }
 
@@ -559,13 +559,13 @@ enum SourceRepublishSeedModeV0 {
 }
 
 #[derive(Debug, Clone)]
-struct SourceRepublishDependencyScopeV0 {
-    index: omena_query::ReverseDependencyIndexV0,
-    changed_module_interface_paths: BTreeSet<String>,
+pub(crate) struct SourceRepublishDependencyScopeV0 {
+    pub(crate) index: omena_query::ReverseDependencyIndexV0,
+    pub(crate) changed_module_interface_paths: BTreeSet<String>,
 }
 
 #[cfg(feature = "salsa-style-diagnostics")]
-fn reverse_dependency_scope_for_style_change(
+pub(crate) fn reverse_dependency_scope_for_style_change(
     state: &LspShellState,
     style_uri: &str,
 ) -> Option<SourceRepublishDependencyScopeV0> {
@@ -593,7 +593,7 @@ fn reverse_dependency_scope_for_style_change(
 }
 
 #[cfg(not(feature = "salsa-style-diagnostics"))]
-fn reverse_dependency_scope_for_style_change(
+pub(crate) fn reverse_dependency_scope_for_style_change(
     _state: &LspShellState,
     _style_uri: &str,
 ) -> Option<SourceRepublishDependencyScopeV0> {

--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -761,17 +761,21 @@ pub(crate) fn store_disk_diagnostics_shard_with_limits(
         return;
     }
     remove_legacy_disk_diagnostics_cache_dir_once(slot.dir.as_path());
-    if write_disk_diagnostics_shard_atomically(
+    match write_disk_diagnostics_shard_atomically(
         slot.dir.as_path(),
         slot.address.as_str(),
         bytes.as_slice(),
-    )
-    .is_err()
-    {
-        session.borrow_mut().record_write_failure();
-        return;
+    ) {
+        Err(_) => {
+            session.borrow_mut().record_write_failure();
+        }
+        // Stable addresses overwrite in place; only a NEW shard file can
+        // grow the store, so only creations pay the read_dir+stat sweep —
+        // a cold wave stats the directory O(new targets) times, not
+        // O(stores x shard cap).
+        Ok(true) => enforce_disk_diagnostics_cache_caps(slot.dir.as_path(), limits),
+        Ok(false) => {}
     }
-    enforce_disk_diagnostics_cache_caps(slot.dir.as_path(), limits);
 }
 
 /// The content-keyed stage-1 stores this crate has replaced with stable-
@@ -826,16 +830,20 @@ pub(crate) fn stable_cache_shard_address(product: &str, identity_parts: &[&str])
     )
 }
 
+/// Returns whether the write CREATED a new shard file (as opposed to
+/// overwriting one in place) — with stable addresses, only creations can
+/// grow the store, so only creations pay the eviction sweep.
 fn write_disk_diagnostics_shard_atomically(
     dir: &Path,
     key: &str,
     bytes: &[u8],
-) -> std::io::Result<()> {
+) -> std::io::Result<bool> {
     fs::create_dir_all(dir)?;
     ensure_omena_cache_root_markers(dir);
     let final_path = disk_diagnostics_shard_file_path(dir, key).ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::InvalidInput, "non-hex shard key")
     })?;
+    let existed = final_path.is_file();
     // Same-directory rename keeps the swap atomic on POSIX; the pid suffix
     // keeps concurrent servers (multi-editor, multi-window) from clobbering
     // each other's in-flight temp files.
@@ -846,12 +854,12 @@ fn write_disk_diagnostics_shard_atomically(
         let _ = fs::remove_file(temp_path.as_path());
         // Windows refuses rename-over-existing. A destination that appeared
         // in the meantime means a concurrent server already wrote this
-        // content-addressed shard — that is success, not failure.
+        // shard — that is success, not failure.
         if final_path.is_file() {
-            return Ok(());
+            return Ok(!existed);
         }
     }
-    renamed
+    renamed.map(|_| !existed)
 }
 
 /// Content-addressed keys never overwrite, so growth is bounded here: evict

--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -224,22 +224,6 @@ pub(crate) fn disk_diagnostics_cache_wave_plan_v1(
         .map(|document| document.source_path.as_str())
         .collect::<Vec<_>>();
     source_paths.sort_unstable();
-    let input = DiskDiagnosticsCacheEnvironmentInputV1 {
-        cache_schema_version: DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V1,
-        crate_version: env!("CARGO_PKG_VERSION"),
-        diagnostics_arm: DISK_DIAGNOSTICS_CACHE_ARM_V0,
-        style_paths,
-        source_paths,
-        package_manifests: components.package_manifests,
-        external_sifs: components.external_sifs,
-        resolution_inputs: components.resolution_inputs,
-        severity: components.severity,
-        deep_analysis: components.deep_analysis,
-    };
-    let canonical_bytes = write_omena_canonical_json_bytes_v1(&input).ok()?;
-    let environment_fingerprint = compute_omena_sif_leaf_hash_v1(canonical_bytes.as_slice())
-        .as_str()
-        .to_string();
     let mut content_hash_by_path = std::collections::BTreeMap::new();
     for source in components.style_sources {
         content_hash_by_path.insert(
@@ -253,10 +237,81 @@ pub(crate) fn disk_diagnostics_cache_wave_plan_v1(
             disk_diagnostics_content_hash(document.source_source.as_bytes()),
         );
     }
+    // Two classes of resolution facts are DERIVED from corpus members whose
+    // content hashes are already manifest rows — a strictly stronger guard —
+    // so they must not re-enter the environment fingerprint, where a single
+    // member's save would invalidate the whole store:
+    //  - disk candidate identities (length+mtime snapshots of member files);
+    //  - bridge SIFs GENERATED from member files (chain-import targets):
+    //    their bytes embed the member's content, and every compute that
+    //    reads such a SIF reaches the member through an import edge, so the
+    //    member sits in that compute's recorded read-set.
+    // Only facts about the world OUTSIDE the corpora stay environmental.
+    let resolution_inputs = OmenaQueryStyleResolutionInputsV0 {
+        disk_style_path_identities: components
+            .resolution_inputs
+            .disk_style_path_identities
+            .iter()
+            .filter(|identity| {
+                !disk_diagnostics_corpus_contains_path(
+                    &content_hash_by_path,
+                    identity.style_path.as_str(),
+                )
+            })
+            .cloned()
+            .collect(),
+        ..components.resolution_inputs.clone()
+    };
+    let environmental_external_sifs = components
+        .external_sifs
+        .iter()
+        .filter(|input| {
+            !disk_diagnostics_corpus_contains_path(
+                &content_hash_by_path,
+                input.sif.canonical_url.as_str(),
+            ) && !disk_diagnostics_corpus_contains_path(
+                &content_hash_by_path,
+                input.canonical_url.as_str(),
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let input = DiskDiagnosticsCacheEnvironmentInputV1 {
+        cache_schema_version: DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V1,
+        crate_version: env!("CARGO_PKG_VERSION"),
+        diagnostics_arm: DISK_DIAGNOSTICS_CACHE_ARM_V0,
+        style_paths,
+        source_paths,
+        package_manifests: components.package_manifests,
+        external_sifs: environmental_external_sifs.as_slice(),
+        resolution_inputs: &resolution_inputs,
+        severity: components.severity,
+        deep_analysis: components.deep_analysis,
+    };
+    let canonical_bytes = write_omena_canonical_json_bytes_v1(&input).ok()?;
+    let environment_fingerprint = compute_omena_sif_leaf_hash_v1(canonical_bytes.as_slice())
+        .as_str()
+        .to_string();
     Some(DiskDiagnosticsCacheWavePlanV0 {
         environment_fingerprint,
         content_hash_by_path: std::sync::Arc::new(content_hash_by_path),
     })
+}
+
+/// Corpus membership across the two path vocabularies in play: corpus maps
+/// are keyed by `file://` URIs while resolver disk identities carry plain
+/// filesystem paths.
+fn disk_diagnostics_corpus_contains_path(
+    content_hash_by_path: &std::collections::BTreeMap<String, String>,
+    path: &str,
+) -> bool {
+    if content_hash_by_path.contains_key(path) {
+        return true;
+    }
+    if let Some(stripped) = path.strip_prefix("file://") {
+        return content_hash_by_path.contains_key(stripped);
+    }
+    content_hash_by_path.contains_key(format!("file://{path}").as_str())
 }
 
 fn disk_diagnostics_content_hash(bytes: &[u8]) -> String {
@@ -1070,6 +1125,141 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
             fingerprints.len(),
             8,
             "every membership / settings variation must move the fingerprint"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn corpus_backed_bridge_sifs_do_not_move_the_environment_fingerprint()
+    -> Result<(), &'static str> {
+        let base_fingerprint = TraceFixture::base()
+            .plan()
+            .ok_or("base plan")?
+            .environment_fingerprint;
+
+        // A bridge SIF generated FROM a corpus member (chain-import target):
+        // its bytes embed the member's content, which is already a manifest
+        // row, so it must stay OUT of the environment fingerprint.
+        let member_sif = |content: &[u8]| -> Option<OmenaQueryExternalSifInputV0> {
+            let sif = omena_sif::OmenaSifV1::from_static_exports(
+                FIXTURE_DEP,
+                omena_sif::OmenaSifGeneratorV1 {
+                    name: "bridge".to_string(),
+                    version: "0.1.0".to_string(),
+                    toolchain_id: "bridge@0.1.0".to_string(),
+                },
+                omena_sif::OmenaSifSourceV1 {
+                    syntax: omena_sif::OmenaSifSourceSyntaxV1::Scss,
+                },
+                omena_sif::OmenaSifExportsV1 {
+                    variables: Vec::new(),
+                    mixins: Vec::new(),
+                    functions: Vec::new(),
+                    placeholders: Vec::new(),
+                    forwards: Vec::new(),
+                },
+                Vec::new(),
+                content,
+            )
+            .ok()?;
+            Some(OmenaQueryExternalSifInputV0 {
+                canonical_url: FIXTURE_DEP.to_string(),
+                sif,
+            })
+        };
+        let mut corpus_backed = TraceFixture::base();
+        corpus_backed
+            .external_sifs
+            .push(member_sif(b"$brand: red;").ok_or("member sif")?);
+        assert_eq!(
+            corpus_backed
+                .plan()
+                .ok_or("corpus-backed plan")?
+                .environment_fingerprint,
+            base_fingerprint,
+            "a member-derived SIF must not enter the environment fingerprint"
+        );
+        let mut corpus_backed_edited = TraceFixture::base();
+        corpus_backed_edited
+            .external_sifs
+            .push(member_sif(b"$brand: blue;").ok_or("edited member sif")?);
+        assert_eq!(
+            corpus_backed_edited
+                .plan()
+                .ok_or("edited corpus-backed plan")?
+                .environment_fingerprint,
+            base_fingerprint,
+        );
+
+        // A TRUE external SIF stays environmental.
+        let mut external = TraceFixture::base();
+        external
+            .external_sifs
+            .push(fixture_external_sif().ok_or("external sif fixture")?);
+        assert_ne!(
+            external
+                .plan()
+                .ok_or("external plan")?
+                .environment_fingerprint,
+            base_fingerprint,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn corpus_member_disk_identities_do_not_move_the_environment_fingerprint()
+    -> Result<(), &'static str> {
+        let base_fingerprint = TraceFixture::base()
+            .plan()
+            .ok_or("base plan")?
+            .environment_fingerprint;
+
+        // A corpus member's disk identity (length+mtime) is filtered out of
+        // the fingerprint: its content hash already guards it, so a plain
+        // SAVE (mtime move) must not invalidate the whole store.
+        let identity_for = |path: &str, mtime: &str| {
+            omena_query::OmenaQueryStyleModuleDiskCandidateIdentityV0 {
+                style_path: path.to_string(),
+                metadata_identity: format!("file|len20|{mtime}"),
+            }
+        };
+        let mut member = TraceFixture::base();
+        member.resolution_inputs.disk_style_path_identities =
+            vec![identity_for("/repo/src/tokens.module.scss", "mtime1")];
+        assert_eq!(
+            member.plan().ok_or("member plan")?.environment_fingerprint,
+            base_fingerprint,
+        );
+        let mut member_saved = TraceFixture::base();
+        member_saved.resolution_inputs.disk_style_path_identities =
+            vec![identity_for("/repo/src/tokens.module.scss", "mtime2")];
+        assert_eq!(
+            member_saved
+                .plan()
+                .ok_or("member saved plan")?
+                .environment_fingerprint,
+            base_fingerprint,
+        );
+
+        // A disk-only candidate OUTSIDE the corpora stays environmental:
+        // both its presence and its identity move the fingerprint.
+        let mut disk_only = TraceFixture::base();
+        disk_only.resolution_inputs.disk_style_path_identities =
+            vec![identity_for("/repo/src/disk-only.scss", "mtime1")];
+        let disk_only_fingerprint = disk_only
+            .plan()
+            .ok_or("disk only plan")?
+            .environment_fingerprint;
+        assert_ne!(disk_only_fingerprint, base_fingerprint);
+        let mut disk_only_saved = TraceFixture::base();
+        disk_only_saved.resolution_inputs.disk_style_path_identities =
+            vec![identity_for("/repo/src/disk-only.scss", "mtime2")];
+        assert_ne!(
+            disk_only_saved
+                .plan()
+                .ok_or("disk only saved plan")?
+                .environment_fingerprint,
+            disk_only_fingerprint,
         );
         Ok(())
     }

--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -343,6 +343,42 @@ impl DiskDiagnosticsCacheWavePlanV0 {
     }
 }
 
+/// Serial-arm slot construction: the per-resolve analog of the wave plan —
+/// ONE environment fingerprint + content-hash pass covering this resolve.
+pub(crate) fn disk_diagnostics_cache_slot_for_serial_resolve(
+    state: &LspShellState,
+    workspace_folder_uri: Option<&str>,
+    target_style_path: &str,
+    components: &DiskDiagnosticsCacheEnvironmentComponentsV1<'_>,
+) -> Option<DiskDiagnosticsCacheSlotV0> {
+    let plan = disk_diagnostics_cache_wave_plan_v1(components)?;
+    disk_diagnostics_cache_slot_for_resolve(state, workspace_folder_uri, target_style_path, &plan)
+}
+
+/// Serial-arm write-behind: declare the read-set over the committed
+/// summary's edges, then store. Without a summary (the straight-line arm)
+/// there is no sound manifest, so nothing is stored — fail-soft, not
+/// fail-broad. Io errors are swallowed and a session breaker stops
+/// retrying hot.
+pub(crate) fn store_disk_diagnostics_shard_for_serial_resolve(
+    state: &LspShellState,
+    slot: Option<DiskDiagnosticsCacheSlotV0>,
+    committed_cross_file_summary: Option<&omena_query::OmenaQueryCrossFileSummaryV0>,
+    target_style_path: &str,
+    diagnostics: &Value,
+) {
+    let (Some(mut slot), Some(summary)) = (slot, committed_cross_file_summary) else {
+        return;
+    };
+    let read_set_index =
+        omena_query::reverse_dependency_index_from_edges_v0(summary.edges.as_slice());
+    slot.set_read_set_paths(omena_query::diagnostics_read_set_for_target_v0(
+        &read_set_index,
+        target_style_path,
+    ));
+    slot.store_write_behind(state, diagnostics);
+}
+
 /// One resolved cache placement: directory + stable address + the wave plan
 /// it verifies against. Built before the workspace diagnostics compute;
 /// `load` is the manifest-verified read path. The read-set is attached
@@ -623,10 +659,7 @@ fn disk_diagnostics_shard_identity_matches(
 /// parses misses instead of being served; it is an integrity check, not an
 /// authentication mechanism — an actor who can write into `.cache/` already
 /// controls the workspace.
-fn disk_diagnostics_shard_trace_verifies(
-    shard: &Value,
-    slot: &DiskDiagnosticsCacheSlotV0,
-) -> bool {
+fn disk_diagnostics_shard_trace_verifies(shard: &Value, slot: &DiskDiagnosticsCacheSlotV0) -> bool {
     if shard.get("environmentFingerprint").and_then(Value::as_str)
         != Some(slot.environment_fingerprint.as_str())
     {
@@ -838,7 +871,8 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
     }
 }
 
-#[cfg(test)]mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
     use std::collections::BTreeSet;
 
@@ -946,9 +980,7 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
             let plan = self.plan()?;
             let mut slot = DiskDiagnosticsCacheSlotV0 {
                 dir: dir.to_path_buf(),
-                address: disk_diagnostics_stable_shard_address_v1(
-                    self.target_style_path.as_str(),
-                )?,
+                address: disk_diagnostics_stable_shard_address_v1(self.target_style_path.as_str())?,
                 target_style_path: self.target_style_path.clone(),
                 environment_fingerprint: plan.environment_fingerprint.clone(),
                 content_hash_by_path: std::sync::Arc::clone(&plan.content_hash_by_path),
@@ -1010,7 +1042,9 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
     #[test]
     fn stable_address_is_target_identity_only() -> Result<(), &'static str> {
         let dir = temp_cache_dir("address");
-        let base = TraceFixture::base().slot(dir.as_path()).ok_or("base slot")?;
+        let base = TraceFixture::base()
+            .slot(dir.as_path())
+            .ok_or("base slot")?;
         let mut edited = TraceFixture::base();
         edited.style_sources[0].style_source = ".btn { color: blue; }".to_string();
         let edited = edited.slot(dir.as_path()).ok_or("edited slot")?;
@@ -1028,8 +1062,8 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
     }
 
     #[test]
-    fn environment_fingerprint_pins_membership_and_settings_not_content()
-    -> Result<(), &'static str> {
+    fn environment_fingerprint_pins_membership_and_settings_not_content() -> Result<(), &'static str>
+    {
         let base_fingerprint = TraceFixture::base()
             .plan()
             .ok_or("base plan")?
@@ -1040,7 +1074,10 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
         let mut content = TraceFixture::base();
         content.style_sources[2].style_source = ".other { color: hotpink; }".to_string();
         assert_eq!(
-            content.plan().ok_or("content plan")?.environment_fingerprint,
+            content
+                .plan()
+                .ok_or("content plan")?
+                .environment_fingerprint,
             base_fingerprint,
         );
 
@@ -1075,7 +1112,12 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
 
         let mut severity = TraceFixture::base();
         severity.severity = 1;
-        fingerprints.insert(severity.plan().ok_or("severity plan")?.environment_fingerprint);
+        fingerprints.insert(
+            severity
+                .plan()
+                .ok_or("severity plan")?
+                .environment_fingerprint,
+        );
 
         let mut deep_analysis = TraceFixture::base();
         deep_analysis.deep_analysis = true;
@@ -1093,7 +1135,12 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
                 package_json_path: "file:///repo/package.json".to_string(),
                 package_json_source: "{\"name\":\"repo\"}".to_string(),
             });
-        fingerprints.insert(manifest.plan().ok_or("manifest plan")?.environment_fingerprint);
+        fingerprints.insert(
+            manifest
+                .plan()
+                .ok_or("manifest plan")?
+                .environment_fingerprint,
+        );
 
         let mut resolution = TraceFixture::base();
         resolution
@@ -1217,12 +1264,11 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
         // A corpus member's disk identity (length+mtime) is filtered out of
         // the fingerprint: its content hash already guards it, so a plain
         // SAVE (mtime move) must not invalidate the whole store.
-        let identity_for = |path: &str, mtime: &str| {
-            omena_query::OmenaQueryStyleModuleDiskCandidateIdentityV0 {
+        let identity_for =
+            |path: &str, mtime: &str| omena_query::OmenaQueryStyleModuleDiskCandidateIdentityV0 {
                 style_path: path.to_string(),
                 metadata_identity: format!("file|len20|{mtime}"),
-            }
-        };
+            };
         let mut member = TraceFixture::base();
         member.resolution_inputs.disk_style_path_identities =
             vec![identity_for("/repo/src/tokens.module.scss", "mtime1")];
@@ -1273,8 +1319,14 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
         ]);
         store_fixture(&TraceFixture::base(), dir.as_path(), &diagnostics)?;
 
-        let same = TraceFixture::base().slot(dir.as_path()).ok_or("same slot")?;
-        assert_eq!(same.load(), Some(diagnostics.clone()), "identical corpus hits");
+        let same = TraceFixture::base()
+            .slot(dir.as_path())
+            .ok_or("same slot")?;
+        assert_eq!(
+            same.load(),
+            Some(diagnostics.clone()),
+            "identical corpus hits"
+        );
 
         // THE stage-2 property: an edit to a file OUTSIDE the recorded
         // read-set (same membership) still hits.
@@ -1293,9 +1345,8 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
     fn edits_inside_the_read_set_miss_without_deleting_the_shard() -> Result<(), &'static str> {
         let dir = temp_cache_dir("inside-edit");
         let slot = store_fixture(&TraceFixture::base(), dir.as_path(), &json!([]))?;
-        let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
-                .ok_or("shard path")?;
+        let shard_path = disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+            .ok_or("shard path")?;
         assert!(shard_path.is_file());
 
         let mut dep_edit = TraceFixture::base();
@@ -1383,17 +1434,16 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
     }
 
     #[test]
-    fn read_set_paths_outside_the_corpora_are_dropped_from_the_manifest()
-    -> Result<(), &'static str> {
+    fn read_set_paths_outside_the_corpora_are_dropped_from_the_manifest() -> Result<(), &'static str>
+    {
         let dir = temp_cache_dir("foreign-paths");
         let mut fixture = TraceFixture::base();
         fixture
             .read_set
             .push("https://cdn.example/tokens.scss".to_string());
         let slot = store_fixture(&fixture, dir.as_path(), &json!([]))?;
-        let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
-                .ok_or("shard path")?;
+        let shard_path = disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+            .ok_or("shard path")?;
         let shard: Value = serde_json::from_slice(
             fs::read(shard_path.as_path())
                 .map_err(|_| "read shard")?
@@ -1417,13 +1467,15 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
         let dir = temp_cache_dir("garbage");
         let slot = TraceFixture::base().slot(dir.as_path()).ok_or("slot")?;
         let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
-        let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
-                .ok_or("shard path")?;
+        let shard_path = disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+            .ok_or("shard path")?;
         fs::create_dir_all(dir.as_path()).map_err(|_| "create cache dir")?;
 
         fs::write(shard_path.as_path(), b"{ truncated garbage").map_err(|_| "write garbage")?;
-        assert_eq!(load_disk_diagnostics_shard_with_limits(&slot, &limits), None);
+        assert_eq!(
+            load_disk_diagnostics_shard_with_limits(&slot, &limits),
+            None
+        );
         assert!(!shard_path.exists(), "garbage shard must be deleted");
 
         let stale = json!({
@@ -1437,7 +1489,10 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
             serde_json::to_vec(&stale).map_err(|_| "serialize stale")?,
         )
         .map_err(|_| "write stale")?;
-        assert_eq!(load_disk_diagnostics_shard_with_limits(&slot, &limits), None);
+        assert_eq!(
+            load_disk_diagnostics_shard_with_limits(&slot, &limits),
+            None
+        );
         assert!(!shard_path.exists(), "stale-schema shard must be deleted");
         Ok(())
     }
@@ -1457,9 +1512,8 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
             {"message": "x".repeat(512), "range": {"start": {}, "end": {}}},
         ]);
         store_disk_diagnostics_shard_with_limits(&session, &slot, &oversized, &limits);
-        let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
-                .ok_or("shard path")?;
+        let shard_path = disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+            .ok_or("shard path")?;
         assert!(
             !shard_path.exists(),
             "oversized payload must not be written"
@@ -1468,7 +1522,10 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
 
         fs::create_dir_all(dir.as_path()).map_err(|_| "create cache dir")?;
         fs::write(shard_path.as_path(), vec![b'x'; 512]).map_err(|_| "write oversized")?;
-        assert_eq!(load_disk_diagnostics_shard_with_limits(&slot, &limits), None);
+        assert_eq!(
+            load_disk_diagnostics_shard_with_limits(&slot, &limits),
+            None
+        );
         assert!(!shard_path.exists(), "oversized shard must be deleted");
         Ok(())
     }
@@ -1616,8 +1673,7 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
         ]);
         let slot = store_fixture(&TraceFixture::base(), dir.as_path(), &genuine)?;
         let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
-                .ok_or("path")?;
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str()).ok_or("path")?;
         let mut shard: Value = serde_json::from_slice(
             fs::read(shard_path.as_path())
                 .map_err(|_| "read shard")?
@@ -1648,8 +1704,7 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
         let dir = temp_cache_dir("shape");
         let slot = store_fixture(&TraceFixture::base(), dir.as_path(), &json!([]))?;
         let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
-                .ok_or("path")?;
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str()).ok_or("path")?;
         let mut shard: Value = serde_json::from_slice(
             fs::read(shard_path.as_path())
                 .map_err(|_| "read shard")?

--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -1,15 +1,25 @@
-//! RFC 0009 Pillar C (rfcs#66) stage 1: a persistent, content-addressed
-//! workspace style-diagnostics shard store.
+//! RFC 0009 Pillar C (rfcs#66) stage 2: a persistent, verifying-trace
+//! workspace style-diagnostics shard store (the Tidepool — what a tide
+//! leaves behind for the next cold open).
 //!
-//! This is deliberately NOT a serde shim over the salsa database. Each shard
-//! is a standalone JSON file under
-//! `<workspaceFolder>/.cache/omena/diagnostics-cache-v0/` named by the blake3
-//! content hash of the FULL diagnostics input surface; a shard is served only
-//! on an exact key match, which makes a hit byte-identical to a recompute by
-//! construction. Everything here is fail-soft: read errors, unparsable or
-//! oversized shards, and write failures degrade to cache misses without ever
-//! surfacing into the LSP loop. The store is local-workspace-disk only — the
-//! trust boundary's `neverFetch` network invariant is untouched.
+//! Stage 1 keyed each shard by a hash of the FULL diagnostics input surface,
+//! which made a single changed file invalidate every target's shard and paid
+//! an O(corpus) serialize+hash PER TARGET. Stage 2 flips the trace direction
+//! (the verifying-trace rebuilder of Mokhov, Mitchell & Peyton Jones, "Build
+//! Systems à la Carte", ICFP 2018): each shard lives at a STABLE address
+//! derived from the target path alone and records the read-set the compute
+//! actually declared — per-dependency `(path, contentHash)` entries plus an
+//! environment fingerprint over everything path-membership- or settings-
+//! shaped. A lookup re-hashes only the recorded dependencies against the
+//! current surface; a hit therefore survives edits OUTSIDE the target's
+//! dependency cone, and the depfile argument (same recorded inputs => same
+//! reads => same output, with the membership fingerprint pinning the
+//! resolver's candidate space) keeps a verified hit byte-identical to a
+//! recompute. Read-set completeness is oracle-gated, not assumed.
+//! Everything here is fail-soft: read errors, unparsable or oversized
+//! shards, and write failures degrade to cache misses without ever
+//! surfacing into the LSP loop. The store is local-workspace-disk only —
+//! the trust boundary's `neverFetch` network invariant is untouched.
 
 use crate::LspShellState;
 use crate::protocol::file_uri_to_path;
@@ -25,17 +35,28 @@ use std::cell::RefCell;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-pub(crate) const DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V0: &str = "1";
+pub(crate) const DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V1: &str = "2";
 /// Serving more than this many diagnostics from one shard is not a plausible
 /// healthy state; such shards are deleted-as-miss.
 const DISK_DIAGNOSTICS_CACHE_MAX_DIAGNOSTICS: usize = 4096;
+/// A recorded read-set beyond this is not a plausible dependency cone for
+/// one target; such shards are treated as misses instead of hashing forever.
+const DISK_DIAGNOSTICS_CACHE_MAX_DEPS: usize = 16_384;
 const DISK_DIAGNOSTICS_CACHE_SHARD_PRODUCT_V0: &str =
     "omena-lsp-server.disk-diagnostics-cache-shard";
 pub(crate) const DISK_DIAGNOSTICS_CACHE_ENV_KILL_SWITCH: &str = "OMENA_LSP_DISK_CACHE";
+/// Serve-side shadow oracle: when set truthy, verified hits do NOT short-
+/// circuit the wave — the target is recomputed anyway and byte-compared
+/// against the shard, so read-set completeness is checked empirically.
+pub(crate) const DISK_DIAGNOSTICS_CACHE_ORACLE_ENV: &str = "OMENA_LSP_DISK_CACHE_ORACLE";
 /// Lives under `.cache/`, which the workspace style indexer skip-list already
 /// excludes; shard filenames are hex digests so they can never collide with
 /// the thin-client watcher globs (package.json, tsconfig*.json, *.module.*).
-const DISK_DIAGNOSTICS_CACHE_RELATIVE_DIR: &str = ".cache/omena/diagnostics-cache-v0";
+const DISK_DIAGNOSTICS_CACHE_RELATIVE_DIR_V1: &str = ".cache/omena/diagnostics-cache-v1";
+/// The stage-1 store this schema replaces; removed best-effort on the first
+/// write of a session so abandoned content-keyed shards do not sit under the
+/// workspace forever (the whole directory is regenerable by contract).
+const DISK_DIAGNOSTICS_CACHE_LEGACY_RELATIVE_DIR_V0: &str = ".cache/omena/diagnostics-cache-v0";
 /// After this many write failures (read-only fs, sandbox, permissions) the
 /// session stops attempting writes entirely instead of retrying hot.
 const DISK_DIAGNOSTICS_CACHE_MAX_WRITE_FAILURES: usize = 3;
@@ -107,17 +128,20 @@ pub fn disk_diagnostics_cache_contract() -> DiskDiagnosticsCacheBoundaryV0 {
     DiskDiagnosticsCacheBoundaryV0 {
         product: "omena-lsp-server.disk-diagnostics-cache",
         owner: "omena-lsp-server/diskDiagnosticsCache",
-        cache_model: "contentAddressedExactMatchShardStore",
-        storage_location: "<workspaceFolder>/.cache/omena/diagnostics-cache-v0",
+        cache_model: "verifyingTraceStableAddressShardStore",
+        storage_location: "<workspaceFolder>/.cache/omena/diagnostics-cache-v1",
         reuse_policy: vec![
-            "contentAddressedExactKeyMatchOnly",
-            "keyChainsFullDiagnosticsInputSurface",
-            "keyChainsBinaryIdentityFingerprint",
+            "stableAddressPerTargetOneShardEach",
+            "recordedReadSetVerifiedPerDependencyContentHash",
+            "environmentFingerprintPinsMembershipAndSettings",
+            "manifestMustIncludeTargetItself",
+            "binaryIdentityFingerprintVerifiedBeforeServe",
             "schemaValidateShardsBeforeServe",
             "outputDigestVerifiedBeforeServe",
             "diagnosticShapeAndCountValidatedBeforeServe",
             "oversizedOrUnparsableShardsAreDeletedMisses",
-            "neverTrustShardContentBeyondExactKeyServe",
+            "verificationMissesLeaveShardForInPlaceOverwrite",
+            "readSetCompletenessOracleGatedNotAssumed",
         ],
         write_policy: vec![
             "writeBehindAfterComputeOnly",
@@ -133,26 +157,21 @@ pub fn disk_diagnostics_cache_contract() -> DiskDiagnosticsCacheBoundaryV0 {
     }
 }
 
-/// The full input surface of `resolve_style_diagnostics_for_uri`, hashed into
-/// the composite key. Canonical-JSON serialization (sorted object keys) fixes
-/// the byte order; the COMPONENT SET is the correctness contract — every input
-/// that can change the final diagnostics JSON must appear here, plus the
-/// crate/schema/arm versions so stale-format shards can never load.
+/// The environment half of the verifying trace: every input that is NOT a
+/// per-file content read — settings, resolver configuration, external
+/// resolution facts, and the PATH MEMBERSHIP of both corpora. Membership is
+/// load-bearing for soundness: creating or deleting a file can change what a
+/// previously-failing specifier resolves to without touching any recorded
+/// dependency's content, so the candidate space itself is fingerprinted.
+/// Canonical-JSON serialization (sorted object keys) fixes the byte order.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct DiskDiagnosticsCacheKeyInputV0<'a> {
+struct DiskDiagnosticsCacheEnvironmentInputV1<'a> {
     cache_schema_version: &'a str,
     crate_version: &'a str,
-    /// The analysis MECHANISM lives in dependency crates that share the
-    /// workspace version, so the crate version alone cannot distinguish two
-    /// dev builds with edited diagnostics behavior. The running binary's
-    /// identity (length + mtime) does: any rebuild or reinstall invalidates
-    /// every shard, at the cost of one cold start per new binary.
-    binary_fingerprint: &'a str,
     diagnostics_arm: &'a str,
-    target_style_path: &'a str,
-    style_sources: &'a [OmenaQueryStyleSourceInputV0],
-    source_documents: &'a [OmenaQuerySourceDocumentInputV0],
+    style_paths: Vec<&'a str>,
+    source_paths: Vec<&'a str>,
     package_manifests: &'a [OmenaQueryStylePackageManifestV0],
     external_sifs: &'a [OmenaQueryExternalSifInputV0],
     resolution_inputs: &'a OmenaQueryStyleResolutionInputsV0,
@@ -161,8 +180,7 @@ struct DiskDiagnosticsCacheKeyInputV0<'a> {
 }
 
 #[derive(Debug)]
-pub(crate) struct DiskDiagnosticsCacheKeyComponentsV0<'a> {
-    pub(crate) target_style_path: &'a str,
+pub(crate) struct DiskDiagnosticsCacheEnvironmentComponentsV1<'a> {
     pub(crate) style_sources: &'a [OmenaQueryStyleSourceInputV0],
     pub(crate) source_documents: &'a [OmenaQuerySourceDocumentInputV0],
     pub(crate) package_manifests: &'a [OmenaQueryStylePackageManifestV0],
@@ -172,23 +190,89 @@ pub(crate) struct DiskDiagnosticsCacheKeyComponentsV0<'a> {
     pub(crate) deep_analysis: bool,
 }
 
-pub(crate) fn disk_diagnostics_cache_key_v0(
-    components: &DiskDiagnosticsCacheKeyComponentsV0<'_>,
-) -> Option<String> {
-    let input = DiskDiagnosticsCacheKeyInputV0 {
-        cache_schema_version: DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V0,
+/// One dependency row of the recorded read-set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DiskDiagnosticsCacheDepV0 {
+    pub(crate) path: String,
+    pub(crate) content_hash: String,
+}
+
+/// Per-wave verification plan, built ONCE per wave (or per serial resolve):
+/// the environment fingerprint plus a content-hash map over every style and
+/// source input. Stage 1 re-serialized the full surface per target; this is
+/// the O(corpus)-once replacement that both `load` verification and `store`
+/// manifest construction read from.
+#[derive(Debug, Clone)]
+pub(crate) struct DiskDiagnosticsCacheWavePlanV0 {
+    environment_fingerprint: String,
+    content_hash_by_path: std::sync::Arc<std::collections::BTreeMap<String, String>>,
+}
+
+pub(crate) fn disk_diagnostics_cache_wave_plan_v1(
+    components: &DiskDiagnosticsCacheEnvironmentComponentsV1<'_>,
+) -> Option<DiskDiagnosticsCacheWavePlanV0> {
+    let mut style_paths = components
+        .style_sources
+        .iter()
+        .map(|source| source.style_path.as_str())
+        .collect::<Vec<_>>();
+    style_paths.sort_unstable();
+    let mut source_paths = components
+        .source_documents
+        .iter()
+        .map(|document| document.source_path.as_str())
+        .collect::<Vec<_>>();
+    source_paths.sort_unstable();
+    let input = DiskDiagnosticsCacheEnvironmentInputV1 {
+        cache_schema_version: DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V1,
         crate_version: env!("CARGO_PKG_VERSION"),
-        binary_fingerprint: disk_diagnostics_cache_binary_fingerprint(),
         diagnostics_arm: DISK_DIAGNOSTICS_CACHE_ARM_V0,
-        target_style_path: components.target_style_path,
-        style_sources: components.style_sources,
-        source_documents: components.source_documents,
+        style_paths,
+        source_paths,
         package_manifests: components.package_manifests,
         external_sifs: components.external_sifs,
         resolution_inputs: components.resolution_inputs,
         severity: components.severity,
         deep_analysis: components.deep_analysis,
     };
+    let canonical_bytes = write_omena_canonical_json_bytes_v1(&input).ok()?;
+    let environment_fingerprint = compute_omena_sif_leaf_hash_v1(canonical_bytes.as_slice())
+        .as_str()
+        .to_string();
+    let mut content_hash_by_path = std::collections::BTreeMap::new();
+    for source in components.style_sources {
+        content_hash_by_path.insert(
+            source.style_path.clone(),
+            disk_diagnostics_content_hash(source.style_source.as_bytes()),
+        );
+    }
+    for document in components.source_documents {
+        content_hash_by_path.insert(
+            document.source_path.clone(),
+            disk_diagnostics_content_hash(document.source_source.as_bytes()),
+        );
+    }
+    Some(DiskDiagnosticsCacheWavePlanV0 {
+        environment_fingerprint,
+        content_hash_by_path: std::sync::Arc::new(content_hash_by_path),
+    })
+}
+
+fn disk_diagnostics_content_hash(bytes: &[u8]) -> String {
+    compute_omena_sif_leaf_hash_v1(bytes).as_str().to_string()
+}
+
+/// The stable shard address: target identity only — never content — so a
+/// target overwrites its own shard in place across edits and rebuilds (one
+/// file per target; the stage-1 accumulation of dead content-keyed shards
+/// cannot recur).
+fn disk_diagnostics_stable_shard_address_v1(target_style_path: &str) -> Option<String> {
+    let input = json!({
+        "cacheSchemaVersion": DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V1,
+        "diagnosticsArm": DISK_DIAGNOSTICS_CACHE_ARM_V0,
+        "targetStylePath": target_style_path,
+    });
     let canonical_bytes = write_omena_canonical_json_bytes_v1(&input).ok()?;
     Some(
         compute_omena_sif_leaf_hash_v1(canonical_bytes.as_slice())
@@ -197,32 +281,52 @@ pub(crate) fn disk_diagnostics_cache_key_v0(
     )
 }
 
-/// One resolved cache placement: directory + composite key + target. Built
-/// before the workspace diagnostics compute; `load` is the exact-match read
-/// path and `store_write_behind` persists the computed result.
+impl DiskDiagnosticsCacheWavePlanV0 {
+    #[cfg(test)]
+    pub(crate) fn environment_fingerprint_for_test(&self) -> &str {
+        self.environment_fingerprint.as_str()
+    }
+}
+
+/// One resolved cache placement: directory + stable address + the wave plan
+/// it verifies against. Built before the workspace diagnostics compute;
+/// `load` is the manifest-verified read path. The read-set is attached
+/// AFTER compute via [`Self::set_read_set_paths`] — a slot without one
+/// never stores (a shard without a manifest could only be membership-
+/// guarded, which is not sound to serve).
 #[derive(Debug, Clone)]
 pub(crate) struct DiskDiagnosticsCacheSlotV0 {
     dir: PathBuf,
-    key: String,
+    address: String,
     target_style_path: String,
+    environment_fingerprint: String,
+    content_hash_by_path: std::sync::Arc<std::collections::BTreeMap<String, String>>,
+    read_set_paths: Option<Vec<String>>,
 }
 
 impl DiskDiagnosticsCacheSlotV0 {
     pub(crate) fn load(&self) -> Option<Value> {
         load_disk_diagnostics_shard_with_limits(
-            self.dir.as_path(),
-            self.key.as_str(),
-            self.target_style_path.as_str(),
+            self,
             &DiskDiagnosticsCacheLimitsV0::with_defaults(),
         )
+    }
+
+    /// Declare the read-set discovered by the compute this slot caches. Paths
+    /// outside the plan's corpora (external facts) are dropped — they are
+    /// covered by the environment fingerprint, not per-file hashes.
+    pub(crate) fn set_read_set_paths(&mut self, paths: impl IntoIterator<Item = String>) {
+        let paths = paths
+            .into_iter()
+            .filter(|path| self.content_hash_by_path.contains_key(path.as_str()))
+            .collect::<Vec<_>>();
+        self.read_set_paths = Some(paths);
     }
 
     pub(crate) fn store_write_behind(&self, state: &LspShellState, diagnostics: &Value) {
         store_disk_diagnostics_shard_with_limits(
             &state.disk_diagnostics_cache_session,
-            self.dir.as_path(),
-            self.key.as_str(),
-            self.target_style_path.as_str(),
+            self,
             diagnostics,
             &DiskDiagnosticsCacheLimitsV0::with_defaults(),
         );
@@ -258,26 +362,17 @@ pub(crate) fn disk_diagnostics_cache_slot_for_resolve(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
     target_style_path: &str,
-    style_sources: &[OmenaQueryStyleSourceInputV0],
-    source_documents: &[OmenaQuerySourceDocumentInputV0],
-    external_sifs: &[OmenaQueryExternalSifInputV0],
-    resolution_inputs: &OmenaQueryStyleResolutionInputsV0,
+    plan: &DiskDiagnosticsCacheWavePlanV0,
 ) -> Option<DiskDiagnosticsCacheSlotV0> {
     let dir = disk_diagnostics_cache_dir(state, workspace_folder_uri)?;
-    let key = disk_diagnostics_cache_key_v0(&DiskDiagnosticsCacheKeyComponentsV0 {
-        target_style_path,
-        style_sources,
-        source_documents,
-        package_manifests: state.resolution.package_manifests.as_slice(),
-        external_sifs,
-        resolution_inputs,
-        severity: state.diagnostics.severity,
-        deep_analysis: state.diagnostics.deep_analysis,
-    })?;
+    let address = disk_diagnostics_stable_shard_address_v1(target_style_path)?;
     Some(DiskDiagnosticsCacheSlotV0 {
         dir,
-        key,
+        address,
         target_style_path: target_style_path.to_string(),
+        environment_fingerprint: plan.environment_fingerprint.clone(),
+        content_hash_by_path: std::sync::Arc::clone(&plan.content_hash_by_path),
+        read_set_paths: None,
     })
 }
 
@@ -304,7 +399,7 @@ pub(crate) fn disk_diagnostics_cache_dir_with_kill_switch(
         return None;
     }
     let root = disk_diagnostics_cache_workspace_root(state, workspace_folder_uri)?;
-    Some(root.join(DISK_DIAGNOSTICS_CACHE_RELATIVE_DIR))
+    Some(root.join(DISK_DIAGNOSTICS_CACHE_RELATIVE_DIR_V1))
 }
 
 fn disk_diagnostics_cache_workspace_root(
@@ -326,6 +421,36 @@ fn disk_diagnostics_cache_workspace_root(
 fn disk_diagnostics_cache_kill_switch_engaged() -> bool {
     std::env::var(DISK_DIAGNOSTICS_CACHE_ENV_KILL_SWITCH)
         .is_ok_and(|value| is_disk_diagnostics_cache_kill_switch_value(value.as_str()))
+}
+
+pub(crate) fn disk_diagnostics_cache_oracle_engaged() -> bool {
+    std::env::var(DISK_DIAGNOSTICS_CACHE_ORACLE_ENV)
+        .is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("on"))
+}
+
+static DISK_DIAGNOSTICS_CACHE_ORACLE_HITS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+static DISK_DIAGNOSTICS_CACHE_ORACLE_MISMATCHES: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Shadow-oracle telemetry: a verified hit that is NOT byte-identical to the
+/// recompute means the recorded read-set under-approximates some diagnostics
+/// arm's true read window — a completeness bug to widen, never to ship past.
+pub(crate) fn record_disk_diagnostics_cache_oracle_outcome(target_uri: &str, matched: bool) {
+    if matched {
+        DISK_DIAGNOSTICS_CACHE_ORACLE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return;
+    }
+    DISK_DIAGNOSTICS_CACHE_ORACLE_MISMATCHES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    crate::loop_trace!("disk-cache-oracle MISMATCH target={target_uri}");
+}
+
+#[cfg(test)]
+pub(crate) fn disk_diagnostics_cache_oracle_counts() -> (u64, u64) {
+    (
+        DISK_DIAGNOSTICS_CACHE_ORACLE_HITS.load(std::sync::atomic::Ordering::Relaxed),
+        DISK_DIAGNOSTICS_CACHE_ORACLE_MISMATCHES.load(std::sync::atomic::Ordering::Relaxed),
+    )
 }
 
 pub(crate) fn is_disk_diagnostics_cache_kill_switch_value(value: &str) -> bool {
@@ -377,12 +502,10 @@ fn disk_diagnostics_shard_file_path(dir: &Path, key: &str) -> Option<PathBuf> {
 }
 
 pub(crate) fn load_disk_diagnostics_shard_with_limits(
-    dir: &Path,
-    key: &str,
-    target_style_path: &str,
+    slot: &DiskDiagnosticsCacheSlotV0,
     limits: &DiskDiagnosticsCacheLimitsV0,
 ) -> Option<Value> {
-    let shard_path = disk_diagnostics_shard_file_path(dir, key)?;
+    let shard_path = disk_diagnostics_shard_file_path(slot.dir.as_path(), slot.address.as_str())?;
     let metadata = fs::metadata(shard_path.as_path()).ok()?;
     if !metadata.is_file() {
         return None;
@@ -396,27 +519,36 @@ pub(crate) fn load_disk_diagnostics_shard_with_limits(
         let _ = fs::remove_file(shard_path.as_path());
         return None;
     };
-    if !disk_diagnostics_shard_matches(&shard, key, target_style_path) {
+    if !disk_diagnostics_shard_identity_matches(&shard, slot) {
+        // A foreign format, arm, build, or target at this address is dead
+        // weight; a stable address means the overwrite would happen anyway.
         let _ = fs::remove_file(shard_path.as_path());
+        return None;
+    }
+    if !disk_diagnostics_shard_trace_verifies(&shard, slot) {
+        // A clean verification miss (content or environment moved on): the
+        // shard is NOT deleted — the recompute overwrites it in place.
         return None;
     }
     shard.get_mut("diagnosticsJson").map(Value::take)
 }
 
-/// The composite key proves the INPUTS match; the stored `outputDigest`
-/// (blake3 over the canonical-JSON diagnostics bytes) binds the OUTPUT to
-/// what the writer computed for those inputs, so bit-rot, truncation that
-/// still parses, or a payload swapped under a valid key all miss instead of
-/// being served. The digest carries no secret — it is an integrity check
-/// against corruption and buggy writes, not an authentication mechanism;
-/// an actor who can write into `.cache/` already controls the workspace.
-fn disk_diagnostics_shard_matches(shard: &Value, key: &str, target_style_path: &str) -> bool {
+/// Structural identity: is this shard the CURRENT format, build, and target
+/// for its address? Failing this is corruption or staleness worth deleting.
+fn disk_diagnostics_shard_identity_matches(
+    shard: &Value,
+    slot: &DiskDiagnosticsCacheSlotV0,
+) -> bool {
     shard.get("schemaVersion").and_then(Value::as_str)
-        == Some(DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V0)
+        == Some(DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V1)
         && shard.get("product").and_then(Value::as_str)
             == Some(DISK_DIAGNOSTICS_CACHE_SHARD_PRODUCT_V0)
-        && shard.get("key").and_then(Value::as_str) == Some(key)
-        && shard.get("targetStylePath").and_then(Value::as_str) == Some(target_style_path)
+        && shard.get("diagnosticsArm").and_then(Value::as_str)
+            == Some(DISK_DIAGNOSTICS_CACHE_ARM_V0)
+        && shard.get("binaryFingerprint").and_then(Value::as_str)
+            == Some(disk_diagnostics_cache_binary_fingerprint())
+        && shard.get("targetStylePath").and_then(Value::as_str)
+            == Some(slot.target_style_path.as_str())
         && shard
             .get("diagnosticsJson")
             .is_some_and(disk_diagnostics_payload_is_well_formed)
@@ -425,6 +557,46 @@ fn disk_diagnostics_shard_matches(shard: &Value, key: &str, target_style_path: &
                 .get("diagnosticsJson")
                 .and_then(disk_diagnostics_output_digest)
                 .as_deref()
+}
+
+/// The verifying trace itself: the recorded environment fingerprint must
+/// equal the current one, and every recorded dependency's content hash must
+/// equal the current surface's. The recorded manifest must include the
+/// target — a manifest that never read its own target is not a plausible
+/// trace. The stored `outputDigest` (checked in identity above) binds the
+/// OUTPUT to what the writer computed, so bit-rot or truncation that still
+/// parses misses instead of being served; it is an integrity check, not an
+/// authentication mechanism — an actor who can write into `.cache/` already
+/// controls the workspace.
+fn disk_diagnostics_shard_trace_verifies(
+    shard: &Value,
+    slot: &DiskDiagnosticsCacheSlotV0,
+) -> bool {
+    if shard.get("environmentFingerprint").and_then(Value::as_str)
+        != Some(slot.environment_fingerprint.as_str())
+    {
+        return false;
+    }
+    let Some(deps) = shard.get("depsManifest").and_then(Value::as_array) else {
+        return false;
+    };
+    if deps.is_empty() || deps.len() > DISK_DIAGNOSTICS_CACHE_MAX_DEPS {
+        return false;
+    }
+    let mut saw_target = false;
+    for dep in deps {
+        let (Some(path), Some(content_hash)) = (
+            dep.get("path").and_then(Value::as_str),
+            dep.get("contentHash").and_then(Value::as_str),
+        ) else {
+            return false;
+        };
+        if slot.content_hash_by_path.get(path).map(String::as_str) != Some(content_hash) {
+            return false;
+        }
+        saw_target |= path == slot.target_style_path.as_str();
+    }
+    saw_target
 }
 
 /// Every served element must look like an LSP diagnostic (object with a
@@ -454,23 +626,47 @@ fn disk_diagnostics_output_digest(diagnostics: &Value) -> Option<String> {
 
 pub(crate) fn store_disk_diagnostics_shard_with_limits(
     session: &RefCell<DiskDiagnosticsCacheSessionV0>,
-    dir: &Path,
-    key: &str,
-    target_style_path: &str,
+    slot: &DiskDiagnosticsCacheSlotV0,
     diagnostics: &Value,
     limits: &DiskDiagnosticsCacheLimitsV0,
 ) {
     if session.borrow().writes_disabled() || !disk_diagnostics_payload_is_well_formed(diagnostics) {
         return;
     }
+    // No declared read-set, or one that never read its own target: nothing
+    // sound to record, so nothing is stored (fail-soft, not fail-broad).
+    let Some(read_set_paths) = slot.read_set_paths.as_ref() else {
+        return;
+    };
+    if read_set_paths.len() > DISK_DIAGNOSTICS_CACHE_MAX_DEPS
+        || !read_set_paths
+            .iter()
+            .any(|path| path == slot.target_style_path.as_str())
+    {
+        return;
+    }
+    let deps_manifest = read_set_paths
+        .iter()
+        .filter_map(|path| {
+            slot.content_hash_by_path
+                .get(path.as_str())
+                .map(|content_hash| DiskDiagnosticsCacheDepV0 {
+                    path: path.clone(),
+                    content_hash: content_hash.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
     let Some(output_digest) = disk_diagnostics_output_digest(diagnostics) else {
         return;
     };
     let shard = json!({
-        "schemaVersion": DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V0,
+        "schemaVersion": DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V1,
         "product": DISK_DIAGNOSTICS_CACHE_SHARD_PRODUCT_V0,
-        "key": key,
-        "targetStylePath": target_style_path,
+        "diagnosticsArm": DISK_DIAGNOSTICS_CACHE_ARM_V0,
+        "binaryFingerprint": disk_diagnostics_cache_binary_fingerprint(),
+        "targetStylePath": slot.target_style_path.as_str(),
+        "environmentFingerprint": slot.environment_fingerprint.as_str(),
+        "depsManifest": deps_manifest,
         "outputDigest": output_digest,
         "diagnosticsJson": diagnostics,
     });
@@ -480,11 +676,42 @@ pub(crate) fn store_disk_diagnostics_shard_with_limits(
     if bytes.len() as u64 > limits.max_shard_bytes {
         return;
     }
-    if write_disk_diagnostics_shard_atomically(dir, key, bytes.as_slice()).is_err() {
+    remove_legacy_disk_diagnostics_cache_dir_once(slot.dir.as_path());
+    if write_disk_diagnostics_shard_atomically(
+        slot.dir.as_path(),
+        slot.address.as_str(),
+        bytes.as_slice(),
+    )
+    .is_err()
+    {
         session.borrow_mut().record_write_failure();
         return;
     }
-    enforce_disk_diagnostics_cache_caps(dir, limits);
+    enforce_disk_diagnostics_cache_caps(slot.dir.as_path(), limits);
+}
+
+/// Best-effort, once per process: drop the abandoned stage-1 store next to
+/// this one. Its shards were content-keyed (dead on any input change) and
+/// the directory is regenerable by contract.
+fn remove_legacy_disk_diagnostics_cache_dir_once(current_dir: &Path) {
+    static LEGACY_SWEEP: std::sync::Once = std::sync::Once::new();
+    LEGACY_SWEEP.call_once(|| remove_legacy_disk_diagnostics_cache_dir(current_dir));
+}
+
+fn remove_legacy_disk_diagnostics_cache_dir(current_dir: &Path) {
+    let Some(omena_root) = current_dir.parent() else {
+        return;
+    };
+    let Some(legacy_name) = Path::new(DISK_DIAGNOSTICS_CACHE_LEGACY_RELATIVE_DIR_V0)
+        .file_name()
+        .and_then(|name| name.to_str())
+    else {
+        return;
+    };
+    let legacy_dir = omena_root.join(legacy_name);
+    if legacy_dir != current_dir && legacy_dir.is_dir() {
+        let _ = fs::remove_dir_all(legacy_dir);
+    }
 }
 
 fn write_disk_diagnostics_shard_atomically(
@@ -556,15 +783,14 @@ fn enforce_disk_diagnostics_cache_caps(dir: &Path, limits: &DiskDiagnosticsCache
     }
 }
 
-#[cfg(test)]
-mod tests {
+#[cfg(test)]mod tests {
     use super::*;
     use std::collections::BTreeSet;
 
     #[test]
     fn cache_writes_stamp_self_ignore_markers_at_omena_root() -> Result<(), &'static str> {
         let base = temp_cache_dir("markers");
-        let dir = base.join(".cache/omena/diagnostics-cache-v0");
+        let dir = base.join(DISK_DIAGNOSTICS_CACHE_RELATIVE_DIR_V1);
         fs::create_dir_all(dir.as_path()).map_err(|_| "create cache dir")?;
         ensure_omena_cache_root_markers(dir.as_path());
         let omena_root = dir.parent().ok_or("omena root")?;
@@ -592,7 +818,15 @@ mod tests {
         dir
     }
 
-    struct KeyFixture {
+    const FIXTURE_TARGET: &str = "file:///repo/src/App.module.scss";
+    const FIXTURE_DEP: &str = "file:///repo/src/tokens.module.scss";
+    const FIXTURE_UNRELATED: &str = "file:///repo/src/Other.module.scss";
+    const FIXTURE_SOURCE: &str = "file:///repo/src/App.tsx";
+
+    /// The verifying-trace fixture: a three-file style corpus where the
+    /// target's recorded read-set covers the target, ONE dependency, and
+    /// ONE source document — and deliberately NOT the unrelated file.
+    struct TraceFixture {
         target_style_path: String,
         style_sources: Vec<OmenaQueryStyleSourceInputV0>,
         source_documents: Vec<OmenaQuerySourceDocumentInputV0>,
@@ -601,18 +835,29 @@ mod tests {
         resolution_inputs: OmenaQueryStyleResolutionInputsV0,
         severity: u8,
         deep_analysis: bool,
+        read_set: Vec<String>,
     }
 
-    impl KeyFixture {
+    impl TraceFixture {
         fn base() -> Self {
             Self {
-                target_style_path: "file:///repo/src/App.module.scss".to_string(),
-                style_sources: vec![OmenaQueryStyleSourceInputV0 {
-                    style_path: "file:///repo/src/App.module.scss".to_string(),
-                    style_source: ".btn { color: red; }".to_string(),
-                }],
+                target_style_path: FIXTURE_TARGET.to_string(),
+                style_sources: vec![
+                    OmenaQueryStyleSourceInputV0 {
+                        style_path: FIXTURE_TARGET.to_string(),
+                        style_source: ".btn { color: red; }".to_string(),
+                    },
+                    OmenaQueryStyleSourceInputV0 {
+                        style_path: FIXTURE_DEP.to_string(),
+                        style_source: "$brand: red;".to_string(),
+                    },
+                    OmenaQueryStyleSourceInputV0 {
+                        style_path: FIXTURE_UNRELATED.to_string(),
+                        style_source: ".other { color: green; }".to_string(),
+                    },
+                ],
                 source_documents: vec![OmenaQuerySourceDocumentInputV0 {
-                    source_path: "file:///repo/src/App.tsx".to_string(),
+                    source_path: FIXTURE_SOURCE.to_string(),
                     source_source: "import styles from './App.module.scss';".to_string(),
                     source_syntax_index: None,
                     has_unresolved_style_import: false,
@@ -622,12 +867,16 @@ mod tests {
                 resolution_inputs: OmenaQueryStyleResolutionInputsV0::default(),
                 severity: 2,
                 deep_analysis: false,
+                read_set: vec![
+                    FIXTURE_TARGET.to_string(),
+                    FIXTURE_DEP.to_string(),
+                    FIXTURE_SOURCE.to_string(),
+                ],
             }
         }
 
-        fn key(&self) -> Option<String> {
-            disk_diagnostics_cache_key_v0(&DiskDiagnosticsCacheKeyComponentsV0 {
-                target_style_path: self.target_style_path.as_str(),
+        fn plan(&self) -> Option<DiskDiagnosticsCacheWavePlanV0> {
+            disk_diagnostics_cache_wave_plan_v1(&DiskDiagnosticsCacheEnvironmentComponentsV1 {
                 style_sources: self.style_sources.as_slice(),
                 source_documents: self.source_documents.as_slice(),
                 package_manifests: self.package_manifests.as_slice(),
@@ -637,6 +886,38 @@ mod tests {
                 deep_analysis: self.deep_analysis,
             })
         }
+
+        fn slot(&self, dir: &Path) -> Option<DiskDiagnosticsCacheSlotV0> {
+            let plan = self.plan()?;
+            let mut slot = DiskDiagnosticsCacheSlotV0 {
+                dir: dir.to_path_buf(),
+                address: disk_diagnostics_stable_shard_address_v1(
+                    self.target_style_path.as_str(),
+                )?,
+                target_style_path: self.target_style_path.clone(),
+                environment_fingerprint: plan.environment_fingerprint.clone(),
+                content_hash_by_path: std::sync::Arc::clone(&plan.content_hash_by_path),
+                read_set_paths: None,
+            };
+            slot.set_read_set_paths(self.read_set.iter().cloned());
+            Some(slot)
+        }
+    }
+
+    fn store_fixture(
+        fixture: &TraceFixture,
+        dir: &Path,
+        diagnostics: &Value,
+    ) -> Result<DiskDiagnosticsCacheSlotV0, &'static str> {
+        let slot = fixture.slot(dir).ok_or("slot")?;
+        let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
+        store_disk_diagnostics_shard_with_limits(
+            &session,
+            &slot,
+            diagnostics,
+            &DiskDiagnosticsCacheLimitsV0::with_defaults(),
+        );
+        Ok(slot)
     }
 
     fn fixture_external_sif() -> Option<OmenaQueryExternalSifInputV0> {
@@ -672,51 +953,94 @@ mod tests {
     }
 
     #[test]
-    fn key_is_stable_for_identical_inputs_and_blake3_prefixed() -> Result<(), &'static str> {
-        let key = KeyFixture::base().key().ok_or("base key")?;
-        let key_again = KeyFixture::base().key().ok_or("base key again")?;
-        assert_eq!(key, key_again);
-        assert!(key.starts_with("blake3:"));
+    fn stable_address_is_target_identity_only() -> Result<(), &'static str> {
+        let dir = temp_cache_dir("address");
+        let base = TraceFixture::base().slot(dir.as_path()).ok_or("base slot")?;
+        let mut edited = TraceFixture::base();
+        edited.style_sources[0].style_source = ".btn { color: blue; }".to_string();
+        let edited = edited.slot(dir.as_path()).ok_or("edited slot")?;
+        assert_eq!(
+            base.address, edited.address,
+            "content edits must not move the shard address"
+        );
+        let mut other_target = TraceFixture::base();
+        other_target.target_style_path = FIXTURE_UNRELATED.to_string();
+        other_target.read_set = vec![FIXTURE_UNRELATED.to_string()];
+        let other_target = other_target.slot(dir.as_path()).ok_or("other slot")?;
+        assert_ne!(base.address, other_target.address);
+        assert!(base.address.starts_with("blake3:"));
         Ok(())
     }
 
     #[test]
-    fn key_changes_when_any_input_component_changes() -> Result<(), &'static str> {
-        let mut keys = BTreeSet::new();
-        keys.insert(KeyFixture::base().key().ok_or("base")?);
+    fn environment_fingerprint_pins_membership_and_settings_not_content()
+    -> Result<(), &'static str> {
+        let base_fingerprint = TraceFixture::base()
+            .plan()
+            .ok_or("base plan")?
+            .environment_fingerprint;
 
-        let mut corpus_text = KeyFixture::base();
-        corpus_text.style_sources[0].style_source = ".btn { color: blue; }".to_string();
-        keys.insert(corpus_text.key().ok_or("corpus text")?);
+        // Content-only edits leave the environment fingerprint UNTOUCHED —
+        // that is the whole point of the verifying trace.
+        let mut content = TraceFixture::base();
+        content.style_sources[2].style_source = ".other { color: hotpink; }".to_string();
+        assert_eq!(
+            content.plan().ok_or("content plan")?.environment_fingerprint,
+            base_fingerprint,
+        );
 
-        let mut corpus_path = KeyFixture::base();
-        corpus_path.style_sources[0].style_path = "file:///repo/src/Other.module.scss".to_string();
-        keys.insert(corpus_path.key().ok_or("corpus path")?);
+        let mut fingerprints = BTreeSet::from([base_fingerprint]);
+        let mut membership = TraceFixture::base();
+        membership.style_sources.push(OmenaQueryStyleSourceInputV0 {
+            style_path: "file:///repo/src/new.module.scss".to_string(),
+            style_source: String::new(),
+        });
+        fingerprints.insert(
+            membership
+                .plan()
+                .ok_or("membership plan")?
+                .environment_fingerprint,
+        );
 
-        let mut extra_style = KeyFixture::base();
-        extra_style
-            .style_sources
-            .push(OmenaQueryStyleSourceInputV0 {
-                style_path: "file:///repo/src/theme.scss".to_string(),
-                style_source: "$brand: red;".to_string(),
+        let mut source_membership = TraceFixture::base();
+        source_membership
+            .source_documents
+            .push(OmenaQuerySourceDocumentInputV0 {
+                source_path: "file:///repo/src/New.tsx".to_string(),
+                source_source: String::new(),
+                source_syntax_index: None,
+                has_unresolved_style_import: false,
             });
-        keys.insert(extra_style.key().ok_or("extra style")?);
+        fingerprints.insert(
+            source_membership
+                .plan()
+                .ok_or("source membership plan")?
+                .environment_fingerprint,
+        );
 
-        let mut source_document = KeyFixture::base();
-        source_document.source_documents[0].source_source =
-            "import other from './App.module.scss';".to_string();
-        keys.insert(source_document.key().ok_or("source document")?);
+        let mut severity = TraceFixture::base();
+        severity.severity = 1;
+        fingerprints.insert(severity.plan().ok_or("severity plan")?.environment_fingerprint);
 
-        let mut manifest = KeyFixture::base();
+        let mut deep_analysis = TraceFixture::base();
+        deep_analysis.deep_analysis = true;
+        fingerprints.insert(
+            deep_analysis
+                .plan()
+                .ok_or("deep analysis plan")?
+                .environment_fingerprint,
+        );
+
+        let mut manifest = TraceFixture::base();
         manifest
             .package_manifests
             .push(OmenaQueryStylePackageManifestV0 {
                 package_json_path: "file:///repo/package.json".to_string(),
                 package_json_source: "{\"name\":\"repo\"}".to_string(),
             });
-        keys.insert(manifest.key().ok_or("manifest")?);
+        fingerprints.insert(manifest.plan().ok_or("manifest plan")?.environment_fingerprint);
 
-        let mut resolution = KeyFixture::base();
+        let mut resolution = TraceFixture::base();
         resolution
             .resolution_inputs
             .package_manifests
@@ -724,107 +1048,176 @@ mod tests {
                 package_json_path: "file:///repo/packages/ui/package.json".to_string(),
                 package_json_source: "{\"name\":\"ui\"}".to_string(),
             });
-        keys.insert(resolution.key().ok_or("resolution inputs")?);
+        fingerprints.insert(
+            resolution
+                .plan()
+                .ok_or("resolution plan")?
+                .environment_fingerprint,
+        );
 
-        let mut external_sif = KeyFixture::base();
+        let mut external_sif = TraceFixture::base();
         external_sif
             .external_sifs
             .push(fixture_external_sif().ok_or("external sif fixture")?);
-        keys.insert(external_sif.key().ok_or("external sif")?);
+        fingerprints.insert(
+            external_sif
+                .plan()
+                .ok_or("external sif plan")?
+                .environment_fingerprint,
+        );
 
-        let mut target = KeyFixture::base();
-        target.target_style_path = "file:///repo/src/Other.module.scss".to_string();
-        keys.insert(target.key().ok_or("target")?);
-
-        let mut severity = KeyFixture::base();
-        severity.severity = 1;
-        keys.insert(severity.key().ok_or("severity")?);
-
-        let mut deep_analysis = KeyFixture::base();
-        deep_analysis.deep_analysis = true;
-        keys.insert(deep_analysis.key().ok_or("deep analysis")?);
-
-        assert_eq!(keys.len(), 11, "every varied component must change the key");
+        assert_eq!(
+            fingerprints.len(),
+            8,
+            "every membership / settings variation must move the fingerprint"
+        );
         Ok(())
     }
 
     #[test]
-    fn shard_roundtrips_through_store_and_load() -> Result<(), &'static str> {
-        let dir = temp_cache_dir("roundtrip");
-        let fixture = KeyFixture::base();
-        let key = fixture.key().ok_or("key")?;
+    fn roundtrip_hit_survives_edits_outside_the_read_set() -> Result<(), &'static str> {
+        let dir = temp_cache_dir("outside-edit");
         let diagnostics = json!([
             {"code": "missingCustomProperty", "message": "unknown --brand",
              "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}}},
         ]);
-        let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
-        let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
-        store_disk_diagnostics_shard_with_limits(
-            &session,
-            dir.as_path(),
-            key.as_str(),
-            fixture.target_style_path.as_str(),
-            &diagnostics,
-            &limits,
-        );
+        store_fixture(&TraceFixture::base(), dir.as_path(), &diagnostics)?;
 
-        assert!(
-            disk_diagnostics_shard_file_path(dir.as_path(), key.as_str())
-                .ok_or("shard path")?
-                .is_file()
+        let same = TraceFixture::base().slot(dir.as_path()).ok_or("same slot")?;
+        assert_eq!(same.load(), Some(diagnostics.clone()), "identical corpus hits");
+
+        // THE stage-2 property: an edit to a file OUTSIDE the recorded
+        // read-set (same membership) still hits.
+        let mut outside = TraceFixture::base();
+        outside.style_sources[2].style_source = ".other { color: rebeccapurple; }".to_string();
+        let outside = outside.slot(dir.as_path()).ok_or("outside slot")?;
+        assert_eq!(
+            outside.load(),
+            Some(diagnostics),
+            "an unrelated file's content edit must not invalidate the shard"
         );
-        let loaded = load_disk_diagnostics_shard_with_limits(
-            dir.as_path(),
-            key.as_str(),
-            fixture.target_style_path.as_str(),
-            &limits,
-        );
-        assert_eq!(loaded, Some(diagnostics));
-        assert_eq!(session.borrow().write_failure_count(), 0);
         Ok(())
     }
 
     #[test]
-    fn load_misses_on_key_or_target_mismatch_without_serving_foreign_content()
-    -> Result<(), &'static str> {
-        let dir = temp_cache_dir("mismatch");
-        let fixture = KeyFixture::base();
-        let key = fixture.key().ok_or("key")?;
-        let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
-        let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
-        store_disk_diagnostics_shard_with_limits(
-            &session,
-            dir.as_path(),
-            key.as_str(),
-            fixture.target_style_path.as_str(),
-            &json!([]),
-            &limits,
+    fn edits_inside_the_read_set_miss_without_deleting_the_shard() -> Result<(), &'static str> {
+        let dir = temp_cache_dir("inside-edit");
+        let slot = store_fixture(&TraceFixture::base(), dir.as_path(), &json!([]))?;
+        let shard_path =
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+                .ok_or("shard path")?;
+        assert!(shard_path.is_file());
+
+        let mut dep_edit = TraceFixture::base();
+        dep_edit.style_sources[1].style_source = "$brand: blue;".to_string();
+        let dep_edit = dep_edit.slot(dir.as_path()).ok_or("dep slot")?;
+        assert_eq!(dep_edit.load(), None, "recorded dependency edits must miss");
+        assert!(
+            shard_path.is_file(),
+            "a clean verification miss leaves the shard for in-place overwrite"
         );
 
-        let other_key = "blake3:0000000000000000000000000000000000000000000000000000000000000000";
+        let mut target_edit = TraceFixture::base();
+        target_edit.style_sources[0].style_source = ".btn { color: blue; }".to_string();
+        let target_edit = target_edit.slot(dir.as_path()).ok_or("target slot")?;
+        assert_eq!(target_edit.load(), None, "target edits must miss");
+
+        let mut source_edit = TraceFixture::base();
+        source_edit.source_documents[0].source_source =
+            "import other from './App.module.scss';".to_string();
+        let source_edit = source_edit.slot(dir.as_path()).ok_or("source slot")?;
+        assert_eq!(source_edit.load(), None, "recorded source edits must miss");
+        Ok(())
+    }
+
+    #[test]
+    fn membership_and_settings_changes_miss() -> Result<(), &'static str> {
+        let dir = temp_cache_dir("membership");
+        store_fixture(&TraceFixture::base(), dir.as_path(), &json!([]))?;
+
+        let mut added = TraceFixture::base();
+        added.style_sources.push(OmenaQueryStyleSourceInputV0 {
+            style_path: "file:///repo/src/appeared.module.scss".to_string(),
+            style_source: ".appeared {}".to_string(),
+        });
+        let added = added.slot(dir.as_path()).ok_or("added slot")?;
         assert_eq!(
-            load_disk_diagnostics_shard_with_limits(
-                dir.as_path(),
-                other_key,
-                fixture.target_style_path.as_str(),
-                &limits,
-            ),
+            added.load(),
             None,
+            "a new corpus member can change failed-specifier resolution"
         );
-        // Same shard file, mismatched target: deleted-as-miss.
-        assert_eq!(
-            load_disk_diagnostics_shard_with_limits(
-                dir.as_path(),
-                key.as_str(),
-                "file:///repo/src/Other.module.scss",
-                &limits,
-            ),
-            None,
-        );
+
+        let mut removed = TraceFixture::base();
+        removed.style_sources.remove(2);
+        let removed = removed.slot(dir.as_path()).ok_or("removed slot")?;
+        assert_eq!(removed.load(), None, "membership shrink must miss");
+
+        let mut severity = TraceFixture::base();
+        severity.severity = 1;
+        let severity = severity.slot(dir.as_path()).ok_or("severity slot")?;
+        assert_eq!(severity.load(), None, "settings changes must miss");
+        Ok(())
+    }
+
+    #[test]
+    fn store_requires_a_read_set_that_includes_the_target() -> Result<(), &'static str> {
+        let dir = temp_cache_dir("no-read-set");
+        let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
+        let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
+
+        let fixture = TraceFixture::base();
+        let plan = fixture.plan().ok_or("plan")?;
+        let undeclared = DiskDiagnosticsCacheSlotV0 {
+            dir: dir.clone(),
+            address: disk_diagnostics_stable_shard_address_v1(FIXTURE_TARGET).ok_or("address")?,
+            target_style_path: FIXTURE_TARGET.to_string(),
+            environment_fingerprint: plan.environment_fingerprint.clone(),
+            content_hash_by_path: std::sync::Arc::clone(&plan.content_hash_by_path),
+            read_set_paths: None,
+        };
+        store_disk_diagnostics_shard_with_limits(&session, &undeclared, &json!([]), &limits);
         assert!(
-            !disk_diagnostics_shard_file_path(dir.as_path(), key.as_str())
-                .ok_or("shard path")?
-                .exists()
+            !dir.exists(),
+            "a slot without a declared read-set must not store"
+        );
+
+        let mut target_missing = TraceFixture::base();
+        target_missing.read_set = vec![FIXTURE_DEP.to_string()];
+        let target_missing = target_missing.slot(dir.as_path()).ok_or("slot")?;
+        store_disk_diagnostics_shard_with_limits(&session, &target_missing, &json!([]), &limits);
+        assert!(
+            !dir.exists(),
+            "a read-set that never read its own target is not a plausible trace"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn read_set_paths_outside_the_corpora_are_dropped_from_the_manifest()
+    -> Result<(), &'static str> {
+        let dir = temp_cache_dir("foreign-paths");
+        let mut fixture = TraceFixture::base();
+        fixture
+            .read_set
+            .push("https://cdn.example/tokens.scss".to_string());
+        let slot = store_fixture(&fixture, dir.as_path(), &json!([]))?;
+        let shard_path =
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+                .ok_or("shard path")?;
+        let shard: Value = serde_json::from_slice(
+            fs::read(shard_path.as_path())
+                .map_err(|_| "read shard")?
+                .as_slice(),
+        )
+        .map_err(|_| "parse shard")?;
+        let deps = shard
+            .get("depsManifest")
+            .and_then(Value::as_array)
+            .ok_or("deps manifest")?;
+        assert_eq!(
+            deps.len(),
+            3,
+            "external facts are environment-fingerprinted, not per-dep entries"
         );
         Ok(())
     }
@@ -832,25 +1225,21 @@ mod tests {
     #[test]
     fn garbage_and_stale_schema_shards_are_deleted_misses() -> Result<(), &'static str> {
         let dir = temp_cache_dir("garbage");
-        let key = KeyFixture::base().key().ok_or("key")?;
-        let target = "file:///repo/src/App.module.scss";
+        let slot = TraceFixture::base().slot(dir.as_path()).ok_or("slot")?;
         let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
         let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), key.as_str()).ok_or("shard path")?;
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+                .ok_or("shard path")?;
         fs::create_dir_all(dir.as_path()).map_err(|_| "create cache dir")?;
 
         fs::write(shard_path.as_path(), b"{ truncated garbage").map_err(|_| "write garbage")?;
-        assert_eq!(
-            load_disk_diagnostics_shard_with_limits(dir.as_path(), key.as_str(), target, &limits),
-            None,
-        );
+        assert_eq!(load_disk_diagnostics_shard_with_limits(&slot, &limits), None);
         assert!(!shard_path.exists(), "garbage shard must be deleted");
 
         let stale = json!({
             "schemaVersion": "999",
             "product": DISK_DIAGNOSTICS_CACHE_SHARD_PRODUCT_V0,
-            "key": key,
-            "targetStylePath": target,
+            "targetStylePath": FIXTURE_TARGET,
             "diagnosticsJson": [],
         });
         fs::write(
@@ -858,37 +1247,16 @@ mod tests {
             serde_json::to_vec(&stale).map_err(|_| "serialize stale")?,
         )
         .map_err(|_| "write stale")?;
-        assert_eq!(
-            load_disk_diagnostics_shard_with_limits(dir.as_path(), key.as_str(), target, &limits),
-            None,
-        );
+        assert_eq!(load_disk_diagnostics_shard_with_limits(&slot, &limits), None);
         assert!(!shard_path.exists(), "stale-schema shard must be deleted");
-
-        let non_array = json!({
-            "schemaVersion": DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V0,
-            "product": DISK_DIAGNOSTICS_CACHE_SHARD_PRODUCT_V0,
-            "key": key,
-            "targetStylePath": target,
-            "diagnosticsJson": {"not": "an array"},
-        });
-        fs::write(
-            shard_path.as_path(),
-            serde_json::to_vec(&non_array).map_err(|_| "serialize non-array")?,
-        )
-        .map_err(|_| "write non-array")?;
-        assert_eq!(
-            load_disk_diagnostics_shard_with_limits(dir.as_path(), key.as_str(), target, &limits),
-            None,
-        );
-        assert!(!shard_path.exists(), "non-array shard must be deleted");
         Ok(())
     }
 
     #[test]
     fn oversized_shards_are_neither_written_nor_served() -> Result<(), &'static str> {
         let dir = temp_cache_dir("oversize");
-        let key = KeyFixture::base().key().ok_or("key")?;
-        let target = "file:///repo/src/App.module.scss";
+        let fixture = TraceFixture::base();
+        let slot = fixture.slot(dir.as_path()).ok_or("slot")?;
         let limits = DiskDiagnosticsCacheLimitsV0 {
             max_shard_bytes: 128,
             max_shards: 256,
@@ -898,16 +1266,10 @@ mod tests {
         let oversized = json!([
             {"message": "x".repeat(512), "range": {"start": {}, "end": {}}},
         ]);
-        store_disk_diagnostics_shard_with_limits(
-            &session,
-            dir.as_path(),
-            key.as_str(),
-            target,
-            &oversized,
-            &limits,
-        );
+        store_disk_diagnostics_shard_with_limits(&session, &slot, &oversized, &limits);
         let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), key.as_str()).ok_or("shard path")?;
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+                .ok_or("shard path")?;
         assert!(
             !shard_path.exists(),
             "oversized payload must not be written"
@@ -916,10 +1278,7 @@ mod tests {
 
         fs::create_dir_all(dir.as_path()).map_err(|_| "create cache dir")?;
         fs::write(shard_path.as_path(), vec![b'x'; 512]).map_err(|_| "write oversized")?;
-        assert_eq!(
-            load_disk_diagnostics_shard_with_limits(dir.as_path(), key.as_str(), target, &limits),
-            None,
-        );
+        assert_eq!(load_disk_diagnostics_shard_with_limits(&slot, &limits), None);
         assert!(!shard_path.exists(), "oversized shard must be deleted");
         Ok(())
     }
@@ -931,17 +1290,15 @@ mod tests {
         let blocker = base.join("blocker");
         fs::write(blocker.as_path(), b"not a directory").map_err(|_| "write blocker")?;
         let undeliverable_dir = blocker.join("nested");
-        let key = KeyFixture::base().key().ok_or("key")?;
-        let target = "file:///repo/src/App.module.scss";
+        let fixture = TraceFixture::base();
+        let undeliverable_slot = fixture.slot(undeliverable_dir.as_path()).ok_or("slot")?;
         let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
         let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
 
         for _ in 0..5 {
             store_disk_diagnostics_shard_with_limits(
                 &session,
-                undeliverable_dir.as_path(),
-                key.as_str(),
-                target,
+                &undeliverable_slot,
                 &json!([]),
                 &limits,
             );
@@ -954,14 +1311,8 @@ mod tests {
         assert!(session.borrow().writes_disabled());
 
         let healthy_dir = base.join("healthy");
-        store_disk_diagnostics_shard_with_limits(
-            &session,
-            healthy_dir.as_path(),
-            key.as_str(),
-            target,
-            &json!([]),
-            &limits,
-        );
+        let healthy_slot = fixture.slot(healthy_dir.as_path()).ok_or("healthy slot")?;
+        store_disk_diagnostics_shard_with_limits(&session, &healthy_slot, &json!([]), &limits);
         assert!(
             !healthy_dir.exists(),
             "writes stay disabled for the session once the breaker trips",
@@ -972,33 +1323,31 @@ mod tests {
     #[test]
     fn caps_evict_oldest_shards_first_and_keep_the_newest() -> Result<(), &'static str> {
         let dir = temp_cache_dir("caps");
-        let target = "file:///repo/src/App.module.scss";
         let limits = DiskDiagnosticsCacheLimitsV0 {
             max_shard_bytes: 4 * 1024 * 1024,
             max_shards: 2,
             max_total_bytes: 64 * 1024 * 1024,
         };
         let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
-        let keys = ["blake3:aaaa", "blake3:bbbb", "blake3:cccc"];
-        for key in keys {
-            store_disk_diagnostics_shard_with_limits(
-                &session,
-                dir.as_path(),
-                key,
-                target,
-                &json!([]),
-                &limits,
-            );
+        let targets = [FIXTURE_TARGET, FIXTURE_DEP, FIXTURE_UNRELATED];
+        let mut addresses = Vec::new();
+        for target in targets {
+            let mut fixture = TraceFixture::base();
+            fixture.target_style_path = target.to_string();
+            fixture.read_set = vec![target.to_string()];
+            let slot = fixture.slot(dir.as_path()).ok_or("slot")?;
+            addresses.push(slot.address.clone());
+            store_disk_diagnostics_shard_with_limits(&session, &slot, &json!([]), &limits);
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
 
         assert!(
-            !disk_diagnostics_shard_file_path(dir.as_path(), keys[0])
+            !disk_diagnostics_shard_file_path(dir.as_path(), addresses[0].as_str())
                 .ok_or("evicted path")?
                 .exists()
         );
         assert!(
-            disk_diagnostics_shard_file_path(dir.as_path(), keys[2])
+            disk_diagnostics_shard_file_path(dir.as_path(), addresses[2].as_str())
                 .ok_or("newest path")?
                 .is_file()
         );
@@ -1011,46 +1360,37 @@ mod tests {
     }
 
     #[test]
-    fn total_byte_cap_bounds_the_store() -> Result<(), &'static str> {
-        let dir = temp_cache_dir("byte-cap");
-        let target = "file:///repo/src/App.module.scss";
-        let limits = DiskDiagnosticsCacheLimitsV0 {
-            max_shard_bytes: 10_000,
-            max_shards: 100,
-            max_total_bytes: 300,
-        };
-        let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
-        let diagnostics = json!([
-            {"message": "y".repeat(120), "range": {"start": {}, "end": {}}},
-        ]);
-        store_disk_diagnostics_shard_with_limits(
-            &session,
-            dir.as_path(),
-            "blake3:dddd",
-            target,
-            &diagnostics,
-            &limits,
+    fn stores_overwrite_in_place_instead_of_accumulating() -> Result<(), &'static str> {
+        let dir = temp_cache_dir("overwrite");
+        store_fixture(&TraceFixture::base(), dir.as_path(), &json!([]))?;
+        let mut edited = TraceFixture::base();
+        edited.style_sources[0].style_source = ".btn { color: blue; }".to_string();
+        let slot = store_fixture(&edited, dir.as_path(), &json!([]))?;
+        let shard_files = fs::read_dir(dir.as_path())
+            .map_err(|_| "read cache dir")?
+            .flatten()
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
+            .count();
+        assert_eq!(
+            shard_files, 1,
+            "one target must own exactly one shard file across content edits"
         );
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        store_disk_diagnostics_shard_with_limits(
-            &session,
-            dir.as_path(),
-            "blake3:eeee",
-            target,
-            &diagnostics,
-            &limits,
-        );
+        assert!(slot.load().is_some(), "the overwrite serves the new trace");
+        Ok(())
+    }
 
-        assert!(
-            !disk_diagnostics_shard_file_path(dir.as_path(), "blake3:dddd")
-                .ok_or("evicted path")?
-                .exists()
-        );
-        assert!(
-            disk_diagnostics_shard_file_path(dir.as_path(), "blake3:eeee")
-                .ok_or("kept path")?
-                .is_file()
-        );
+    #[test]
+    fn legacy_stage_one_store_is_swept() -> Result<(), &'static str> {
+        let base = temp_cache_dir("legacy-sweep");
+        let omena_root = base.join(".cache/omena");
+        let legacy_dir = omena_root.join("diagnostics-cache-v0");
+        let current_dir = omena_root.join("diagnostics-cache-v1");
+        fs::create_dir_all(legacy_dir.as_path()).map_err(|_| "create legacy")?;
+        fs::create_dir_all(current_dir.as_path()).map_err(|_| "create current")?;
+        fs::write(legacy_dir.join("dead.json"), b"{}").map_err(|_| "write dead shard")?;
+        remove_legacy_disk_diagnostics_cache_dir(current_dir.as_path());
+        assert!(!legacy_dir.exists(), "the stage-1 store must be removed");
+        assert!(current_dir.exists());
         Ok(())
     }
 
@@ -1081,23 +1421,13 @@ mod tests {
     #[test]
     fn tampered_payload_with_stale_output_digest_is_a_deleted_miss() -> Result<(), &'static str> {
         let dir = temp_cache_dir("digest");
-        let fixture = KeyFixture::base();
-        let key = fixture.key().ok_or("key")?;
-        let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
-        let session = RefCell::new(DiskDiagnosticsCacheSessionV0::default());
         let genuine = json!([
             {"message": "real", "range": {"start": {}, "end": {}}},
         ]);
-        store_disk_diagnostics_shard_with_limits(
-            &session,
-            dir.as_path(),
-            key.as_str(),
-            fixture.target_style_path.as_str(),
-            &genuine,
-            &limits,
-        );
+        let slot = store_fixture(&TraceFixture::base(), dir.as_path(), &genuine)?;
         let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), key.as_str()).ok_or("path")?;
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+                .ok_or("path")?;
         let mut shard: Value = serde_json::from_slice(
             fs::read(shard_path.as_path())
                 .map_err(|_| "read shard")?
@@ -1114,12 +1444,7 @@ mod tests {
         .map_err(|_| "write tampered")?;
 
         assert_eq!(
-            load_disk_diagnostics_shard_with_limits(
-                dir.as_path(),
-                key.as_str(),
-                fixture.target_style_path.as_str(),
-                &limits,
-            ),
+            slot.load(),
             None,
             "payload not matching the output digest must miss",
         );
@@ -1131,22 +1456,20 @@ mod tests {
     fn malformed_diagnostic_elements_are_rejected_even_with_a_valid_digest()
     -> Result<(), &'static str> {
         let dir = temp_cache_dir("shape");
-        let fixture = KeyFixture::base();
-        let key = fixture.key().ok_or("key")?;
-        let limits = DiskDiagnosticsCacheLimitsV0::with_defaults();
-        let malformed = json!(["not-an-object", 42]);
-        let digest = disk_diagnostics_output_digest(&malformed).ok_or("digest")?;
-        let shard = json!({
-            "schemaVersion": DISK_DIAGNOSTICS_CACHE_SCHEMA_VERSION_V0,
-            "product": DISK_DIAGNOSTICS_CACHE_SHARD_PRODUCT_V0,
-            "key": key,
-            "targetStylePath": fixture.target_style_path,
-            "outputDigest": digest,
-            "diagnosticsJson": malformed,
-        });
-        fs::create_dir_all(dir.as_path()).map_err(|_| "create dir")?;
+        let slot = store_fixture(&TraceFixture::base(), dir.as_path(), &json!([]))?;
         let shard_path =
-            disk_diagnostics_shard_file_path(dir.as_path(), key.as_str()).ok_or("path")?;
+            disk_diagnostics_shard_file_path(dir.as_path(), slot.address.as_str())
+                .ok_or("path")?;
+        let mut shard: Value = serde_json::from_slice(
+            fs::read(shard_path.as_path())
+                .map_err(|_| "read shard")?
+                .as_slice(),
+        )
+        .map_err(|_| "parse shard")?;
+        let malformed = json!(["not-an-object", 42]);
+        shard["outputDigest"] =
+            Value::String(disk_diagnostics_output_digest(&malformed).ok_or("digest")?);
+        shard["diagnosticsJson"] = malformed;
         fs::write(
             shard_path.as_path(),
             serde_json::to_vec(&shard).map_err(|_| "serialize")?,
@@ -1154,17 +1477,22 @@ mod tests {
         .map_err(|_| "write")?;
 
         assert_eq!(
-            load_disk_diagnostics_shard_with_limits(
-                dir.as_path(),
-                key.as_str(),
-                fixture.target_style_path.as_str(),
-                &limits,
-            ),
+            slot.load(),
             None,
             "elements without range+message must miss even when digested",
         );
         assert!(!shard_path.exists());
         Ok(())
+    }
+
+    #[test]
+    fn oracle_counters_track_hits_and_mismatches() {
+        let (hits_before, mismatches_before) = disk_diagnostics_cache_oracle_counts();
+        record_disk_diagnostics_cache_oracle_outcome("file:///repo/src/App.module.scss", true);
+        record_disk_diagnostics_cache_oracle_outcome("file:///repo/src/App.module.scss", false);
+        let (hits_after, mismatches_after) = disk_diagnostics_cache_oracle_counts();
+        assert_eq!(hits_after - hits_before, 1);
+        assert_eq!(mismatches_after - mismatches_before, 1);
     }
 
     #[test]
@@ -1196,7 +1524,7 @@ mod tests {
                 false,
             ),
             Some(PathBuf::from(
-                "/omena-disk-cache-kill-switch-root/.cache/omena/diagnostics-cache-v0",
+                "/omena-disk-cache-kill-switch-root/.cache/omena/diagnostics-cache-v1",
             )),
         );
     }
@@ -1224,14 +1552,14 @@ mod tests {
                 false,
             ),
             Some(PathBuf::from(
-                "/omena-disk-cache-owner-root/.cache/omena/diagnostics-cache-v0",
+                "/omena-disk-cache-owner-root/.cache/omena/diagnostics-cache-v1",
             )),
         );
         // Orphan documents fall back to the first registered folder.
         assert_eq!(
             disk_diagnostics_cache_dir_with_kill_switch(&state, None, false),
             Some(PathBuf::from(
-                "/omena-disk-cache-first-root/.cache/omena/diagnostics-cache-v0",
+                "/omena-disk-cache-first-root/.cache/omena/diagnostics-cache-v1",
             )),
         );
     }

--- a/rust/crates/omena-lsp-server/src/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/disk_cache.rs
@@ -53,10 +53,6 @@ pub(crate) const DISK_DIAGNOSTICS_CACHE_ORACLE_ENV: &str = "OMENA_LSP_DISK_CACHE
 /// excludes; shard filenames are hex digests so they can never collide with
 /// the thin-client watcher globs (package.json, tsconfig*.json, *.module.*).
 const DISK_DIAGNOSTICS_CACHE_RELATIVE_DIR_V1: &str = ".cache/omena/diagnostics-cache-v1";
-/// The stage-1 store this schema replaces; removed best-effort on the first
-/// write of a session so abandoned content-keyed shards do not sit under the
-/// workspace forever (the whole directory is regenerable by contract).
-const DISK_DIAGNOSTICS_CACHE_LEGACY_RELATIVE_DIR_V0: &str = ".cache/omena/diagnostics-cache-v0";
 /// After this many write failures (read-only fs, sandbox, permissions) the
 /// session stops attempting writes entirely instead of retrying hot.
 const DISK_DIAGNOSTICS_CACHE_MAX_WRITE_FAILURES: usize = 3;
@@ -778,28 +774,56 @@ pub(crate) fn store_disk_diagnostics_shard_with_limits(
     enforce_disk_diagnostics_cache_caps(slot.dir.as_path(), limits);
 }
 
-/// Best-effort, once per process: drop the abandoned stage-1 store next to
-/// this one. Its shards were content-keyed (dead on any input change) and
-/// the directory is regenerable by contract.
+/// The content-keyed stage-1 stores this crate has replaced with stable-
+/// address stores. Their shards were dead weight on any input change and
+/// the directories accumulated without bound; every directory here is
+/// regenerable by contract.
+const LEGACY_CACHE_DIR_NAMES: &[&str] = &[
+    "diagnostics-cache-v0",
+    "source-occurrence-index-v0",
+    "source-document-index-v0",
+    "source-type-fact-cache-v0",
+    "style-symbol-occurrence-index-v0",
+    "workspace-occurrence-shards-v0",
+];
+
+/// Best-effort, once per process: drop the abandoned content-keyed stores
+/// next to this one.
 fn remove_legacy_disk_diagnostics_cache_dir_once(current_dir: &Path) {
     static LEGACY_SWEEP: std::sync::Once = std::sync::Once::new();
-    LEGACY_SWEEP.call_once(|| remove_legacy_disk_diagnostics_cache_dir(current_dir));
+    LEGACY_SWEEP.call_once(|| remove_legacy_cache_dirs(current_dir));
 }
 
-fn remove_legacy_disk_diagnostics_cache_dir(current_dir: &Path) {
+fn remove_legacy_cache_dirs(current_dir: &Path) {
     let Some(omena_root) = current_dir.parent() else {
         return;
     };
-    let Some(legacy_name) = Path::new(DISK_DIAGNOSTICS_CACHE_LEGACY_RELATIVE_DIR_V0)
-        .file_name()
-        .and_then(|name| name.to_str())
-    else {
-        return;
-    };
-    let legacy_dir = omena_root.join(legacy_name);
-    if legacy_dir != current_dir && legacy_dir.is_dir() {
-        let _ = fs::remove_dir_all(legacy_dir);
+    for legacy_name in LEGACY_CACHE_DIR_NAMES {
+        let legacy_dir = omena_root.join(legacy_name);
+        if legacy_dir != current_dir && legacy_dir.is_dir() {
+            let _ = fs::remove_dir_all(legacy_dir);
+        }
     }
+}
+
+/// Stable shard address for ANY cache subsystem: IDENTITY parts only —
+/// never content — hashed into the shard filename, so one logical entry
+/// overwrites itself in place across content changes while the content key
+/// stays INSIDE the shard as a load-verified field. The Tidepool rule,
+/// shared by every sidecar (the content-keyed alternative grew without
+/// bound: one new file per corpus state, no eviction).
+pub(crate) fn stable_cache_shard_address(product: &str, identity_parts: &[&str]) -> Option<String> {
+    let input = json!({
+        "schemaVersion": "address-v1",
+        "product": product,
+        "identityParts": identity_parts,
+    });
+    let canonical_bytes = write_omena_canonical_json_bytes_v1(&input).ok()?;
+    Some(
+        compute_omena_sif_leaf_hash_v1(canonical_bytes.as_slice())
+            .as_str()
+            .to_string(),
+    )
 }
 
 fn write_disk_diagnostics_shard_atomically(
@@ -1635,7 +1659,7 @@ mod tests {
         fs::create_dir_all(legacy_dir.as_path()).map_err(|_| "create legacy")?;
         fs::create_dir_all(current_dir.as_path()).map_err(|_| "create current")?;
         fs::write(legacy_dir.join("dead.json"), b"{}").map_err(|_| "write dead shard")?;
-        remove_legacy_disk_diagnostics_cache_dir(current_dir.as_path());
+        remove_legacy_cache_dirs(current_dir.as_path());
         assert!(!legacy_dir.exists(), "the stage-1 store must be removed");
         assert!(current_dir.exists());
         Ok(())

--- a/rust/crates/omena-lsp-server/src/external_sif_loader.rs
+++ b/rust/crates/omena-lsp-server/src/external_sif_loader.rs
@@ -1,7 +1,7 @@
 use crate::protocol::{file_uri_to_path, is_style_document_uri, normalize_path};
 use crate::tide::{
-    TideDemandV0, TideFootprintStampV0, TideFootprintV0, TideGateInputsV0, TideInputKindV0,
-    TideLaneConfigV0,
+    TideFootprintStampV0, TideFootprintV0, TideGateInputsV0, TideInputKindV0, TideLaneConfigV0,
+    TideRepublishDemandV0, TideSifDemandV0,
 };
 use crate::{LspShellState, LspTextDocumentState};
 use omena_query::{
@@ -12,7 +12,7 @@ use omena_query::{
 };
 use omena_sif::{read_omena_lock_json_v1, read_omena_sif_json_v1};
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -67,7 +67,9 @@ pub(crate) fn refresh_external_sifs_for_state(state: &mut LspShellState) {
     if state.external_sif_refresh_deferred {
         crate::loop_trace!("sif-demand reason=state-refresh");
         let tick = state.tide_tick;
-        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, tick);
+        state
+            .tide_sif_lane
+            .deposit(TideSifDemandV0::refresh(), tick);
         return;
     }
     refresh_external_sifs_for_state_immediate(state);
@@ -131,7 +133,9 @@ pub(crate) fn refresh_external_sifs_for_bridge_source_delta(
         state.tide_ledger.advance(&[TideInputKindV0::DocumentSet]);
         state.tide_reopen_republish_window();
         let tick = state.tide_tick;
-        state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, tick);
+        state
+            .tide_sif_lane
+            .deposit(TideSifDemandV0::refresh(), tick);
         return;
     }
     let previous_sources = previous_sources.iter().cloned().collect::<BTreeSet<_>>();
@@ -227,7 +231,9 @@ pub(crate) fn bridge_sources_for_style_uris(
 pub fn enable_deferred_external_sif_refresh(state: &mut LspShellState) {
     state.external_sif_refresh_deferred = true;
     let tick = state.tide_tick;
-    state.tide_sif_lane.deposit(TideDemandV0::SifRefresh, tick);
+    state
+        .tide_sif_lane
+        .deposit(TideSifDemandV0::refresh(), tick);
 }
 
 pub fn prepare_deferred_external_sif_refresh_job(
@@ -346,19 +352,101 @@ pub fn apply_deferred_external_sif_refresh_result(
         result.external_sifs.len()
     );
     if changed {
+        // Cone seeding (rfcs#111 demand lattice): the republish owed by a
+        // SIF delta is the set of files that import a CHANGED fact, not the
+        // workspace. Computed BEFORE the swap so the old set is diffable.
+        let demand =
+            republish_demand_for_external_sif_delta(state, result.external_sifs.as_slice());
         state.resolution.external_sifs = result.external_sifs;
         invalidate_external_sif_dependents(state);
         // Output cutoff (rfcs#111 §4.1): only a CHANGED SIF set owes the
         // workspace republish; an Eq result blocks downstream entirely.
         state.tide_reopen_republish_window();
         let tick = state.tide_tick;
-        state
-            .tide_republish_lane
-            .deposit(TideDemandV0::WorkspaceRepublish, tick);
+        state.tide_republish_lane.deposit(demand, tick);
     }
     state.resolution.bridge_external_sif_urls = result.bridge_external_sif_urls;
     state.tide_sif_lane.tide_completed(result.generation);
     changed
+}
+
+/// The republish demand a SIF delta deposits: `Cone(importers of every
+/// changed url)` when the loop's reverse-dependency index can attribute
+/// EVERY changed fact, `All` otherwise — a cold start has no index yet
+/// (everything owes its first publish anyway), and an unattributable url
+/// must widen rather than guess. Seeds are direct importers; the flush
+/// takes their reverse closure against the then-current graph.
+#[cfg(feature = "salsa-style-diagnostics")]
+pub(crate) fn republish_demand_for_external_sif_delta(
+    state: &LspShellState,
+    next_external_sifs: &[OmenaQueryExternalSifInputV0],
+) -> TideRepublishDemandV0 {
+    let previous: BTreeMap<&str, &OmenaQueryExternalSifInputV0> = state
+        .resolution
+        .external_sifs
+        .iter()
+        .map(|input| (input.canonical_url.as_str(), input))
+        .collect();
+    let next: BTreeMap<&str, &OmenaQueryExternalSifInputV0> = next_external_sifs
+        .iter()
+        .map(|input| (input.canonical_url.as_str(), input))
+        .collect();
+    let mut changed_urls = BTreeSet::new();
+    for (url, input) in &next {
+        if previous.get(url).is_none_or(|prev| prev != input) {
+            changed_urls.insert(*url);
+        }
+    }
+    for url in previous.keys() {
+        if !next.contains_key(url) {
+            changed_urls.insert(*url);
+        }
+    }
+    if changed_urls.is_empty() {
+        return TideRepublishDemandV0::None;
+    }
+    let memo_slot = state.reverse_dependency_index_memo.borrow();
+    let Some(memo) = memo_slot.as_ref() else {
+        crate::loop_trace!(
+            "republish-demand all: {} changed sif urls, no reverse index",
+            changed_urls.len()
+        );
+        return TideRepublishDemandV0::All;
+    };
+    let mut seeds: BTreeSet<String> = BTreeSet::new();
+    for url in &changed_urls {
+        // A fact can appear as an edge target under its alias key or its
+        // resolved canonical url; consult both, from whichever side of the
+        // delta knows the entry.
+        let resolved_alias = next
+            .get(url)
+            .or_else(|| previous.get(url))
+            .map(|input| input.sif.canonical_url.as_str());
+        let dependents = memo
+            .index
+            .rev
+            .get(*url)
+            .or_else(|| resolved_alias.and_then(|alias| memo.index.rev.get(alias)));
+        let Some(dependents) = dependents else {
+            crate::loop_trace!("republish-demand all: unattributed sif url {url}");
+            return TideRepublishDemandV0::All;
+        };
+        seeds.extend(dependents.iter().cloned());
+    }
+    crate::loop_trace!(
+        "republish-demand cone seeds={} changed_urls={}",
+        seeds.len(),
+        changed_urls.len()
+    );
+    TideRepublishDemandV0::cone(seeds)
+}
+
+#[cfg(not(feature = "salsa-style-diagnostics"))]
+pub(crate) fn republish_demand_for_external_sif_delta(
+    _state: &LspShellState,
+    _next_external_sifs: &[OmenaQueryExternalSifInputV0],
+) -> TideRepublishDemandV0 {
+    TideRepublishDemandV0::All
 }
 
 fn workspace_lockfiles(state: &LspShellState) -> Vec<PathBuf> {

--- a/rust/crates/omena-lsp-server/src/external_sif_loader.rs
+++ b/rust/crates/omena-lsp-server/src/external_sif_loader.rs
@@ -413,6 +413,22 @@ pub(crate) fn republish_demand_for_external_sif_delta(
         );
         return TideRepublishDemandV0::All;
     };
+    // Freshness gate: a memo that predates the latest corpus-shaping input
+    // marks may hold a rev-set that is PRESENT but stale (a just-added
+    // importer missing from it) — presence alone cannot widen, so the epoch
+    // comparison does. Widen, never guess.
+    let corpus_input_mark = state
+        .tide_ledger
+        .mark(TideInputKindV0::DocumentText)
+        .max(state.tide_ledger.mark(TideInputKindV0::DocumentSet));
+    if memo.ledger_epoch < corpus_input_mark {
+        crate::loop_trace!(
+            "republish-demand all: reverse index stale (memo epoch {} < corpus mark {})",
+            memo.ledger_epoch,
+            corpus_input_mark
+        );
+        return TideRepublishDemandV0::All;
+    }
     let mut seeds: BTreeSet<String> = BTreeSet::new();
     for url in &changed_urls {
         // A fact can appear as an edge target under its alias key or its

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -224,10 +224,6 @@ pub(crate) use workspace_index::{
     WorkspaceStyleIndexBudget, index_workspace_style_files_with_budget,
 };
 #[cfg(test)]
-use workspace_occurrences::{
-    source_selector_occurrence_document_keys, style_symbol_occurrence_document_keys,
-};
-#[cfg(test)]
 pub(crate) use workspace_resolution::load_lsp_workspace_style_resolution_inputs;
 pub(crate) use workspace_resolution::{
     initialize_workspace_folders, insert_workspace_folder, refresh_document_workspace_owners,

--- a/rust/crates/omena-lsp-server/src/lib.rs
+++ b/rust/crates/omena-lsp-server/src/lib.rs
@@ -49,7 +49,6 @@ mod workspace_runtime_registry;
 
 pub use boundary::*;
 pub use diagnostics_follow_up::*;
-use disk_cache::disk_diagnostics_cache_slot_for_resolve;
 pub(crate) use document_events::{
     did_change_text_document, did_change_watched_files, did_change_workspace_folders,
     did_close_text_document, did_open_text_document,

--- a/rust/crates/omena-lsp-server/src/message_loop.rs
+++ b/rust/crates/omena-lsp-server/src/message_loop.rs
@@ -217,7 +217,7 @@ fn did_change_configuration(state: &mut LspShellState, params: Option<&Value>) {
         let tick = state.tide_tick;
         state
             .tide_republish_lane
-            .deposit(crate::tide::TideDemandV0::WorkspaceRepublish, tick);
+            .deposit(crate::tide::TideRepublishDemandV0::All, tick);
     }
     if apply_resolution_settings(state, settings.get("resolution")) {
         state

--- a/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
+++ b/rust/crates/omena-lsp-server/src/parallel_style_wave.rs
@@ -102,6 +102,10 @@ struct ParallelStyleWaveTargetPlanV0 {
     document_text: String,
     query_candidates: Vec<OmenaQueryStyleHoverCandidateV0>,
     disk_cache_slot: Option<DiskDiagnosticsCacheSlotV0>,
+    /// Shadow-oracle mode only: the manifest-verified shard value this
+    /// target ALSO computes against. The computed value is what gets
+    /// served; the comparison is telemetry for read-set completeness.
+    oracle_cached_diagnostics: Option<Value>,
 }
 
 fn resolver_identity_index_for_parallel_style_wave(
@@ -231,7 +235,9 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
     // (multi-root corpora, required-document append edges) fall through to
     // the serial arm — running them against a foreign synced revision would
     // be wrong, not just stale.
+    let oracle_engaged = crate::disk_cache::disk_diagnostics_cache_oracle_engaged();
     let mut shared_surface: Option<Arc<ParallelStyleWaveSurfaceV0>> = None;
+    let mut wave_cache_plan: Option<crate::disk_cache::DiskDiagnosticsCacheWavePlanV0> = None;
     let mut group: Vec<ParallelStyleWaveTargetPlanV0> = Vec::new();
     for index in candidate_indices {
         let uri = document_uris[index].as_str();
@@ -256,36 +262,56 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
                 document.workspace_folder_uri.as_deref(),
             ),
         };
-        let surface = match shared_surface.as_ref() {
+        match shared_surface.as_ref() {
             None => {
                 let surface = Arc::new(surface);
                 shared_surface = Some(Arc::clone(&surface));
-                surface
+                // The verification plan is per-wave work: ONE environment
+                // fingerprint + ONE content-hash pass over the corpus,
+                // shared by every target's load and store (stage 1 paid an
+                // O(corpus) serialize+hash per target here).
+                wave_cache_plan = crate::disk_cache::disk_diagnostics_cache_wave_plan_v1(
+                    &crate::disk_cache::DiskDiagnosticsCacheEnvironmentComponentsV1 {
+                        style_sources: surface.style_sources.as_slice(),
+                        source_documents: surface.source_documents.as_slice(),
+                        package_manifests,
+                        external_sifs,
+                        resolution_inputs: &surface.resolution_inputs,
+                        severity: configured_severity,
+                        deep_analysis,
+                    },
+                );
             }
-            Some(shared) if **shared == surface => Arc::clone(shared),
+            Some(shared) if **shared == surface => {}
             Some(_) => continue,
-        };
-        let disk_cache_slot = disk_diagnostics_cache_slot_for_resolve(
-            state,
-            document.workspace_folder_uri.as_deref(),
-            document.uri.as_str(),
-            surface.style_sources.as_slice(),
-            surface.source_documents.as_slice(),
-            external_sifs,
-            &surface.resolution_inputs,
-        );
+        }
+        let disk_cache_slot = wave_cache_plan.as_ref().and_then(|plan| {
+            disk_diagnostics_cache_slot_for_resolve(
+                state,
+                document.workspace_folder_uri.as_deref(),
+                document.uri.as_str(),
+                plan,
+            )
+        });
+        let mut oracle_cached_diagnostics = None;
         if let Some(cached_diagnostics) = disk_cache_slot.as_ref().and_then(|slot| slot.load()) {
-            if let Some(sink) = on_item {
-                sink(index, cached_diagnostics.clone(), None);
+            if oracle_engaged {
+                // Shadow oracle: keep the target in the compute group and
+                // byte-compare after the join; serve the computed value.
+                oracle_cached_diagnostics = Some(cached_diagnostics);
+            } else {
+                if let Some(sink) = on_item {
+                    sink(index, cached_diagnostics.clone(), None);
+                }
+                resolved.insert(
+                    index,
+                    ResolvedParallelStyleTargetV0 {
+                        diagnostics: cached_diagnostics,
+                        disk_cache_slot: None,
+                    },
+                );
+                continue;
             }
-            resolved.insert(
-                index,
-                ResolvedParallelStyleTargetV0 {
-                    diagnostics: cached_diagnostics,
-                    disk_cache_slot: None,
-                },
-            );
-            continue;
         }
         group.push(ParallelStyleWaveTargetPlanV0 {
             index,
@@ -296,6 +322,7 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
                 .map(query_style_hover_candidate_from_lsp)
                 .collect(),
             disk_cache_slot,
+            oracle_cached_diagnostics,
         });
     }
     if group.len() < min_parallel_targets {
@@ -382,7 +409,13 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
             &committed_graph.cross_file_summary,
         ),
     );
-    let computed: Vec<Option<Value>> = pool.install(|| {
+    // The dependency index the verifying-trace manifests are read from: one
+    // build over the committed summary's edges, shared across workers. Each
+    // target records its declared read-set into its cache slot post-compute.
+    let read_set_index = std::sync::Arc::new(omena_query::reverse_dependency_index_from_edges_v0(
+        committed_graph.cross_file_summary.edges.as_slice(),
+    ));
+    let computed: Vec<Option<(Value, Option<DiskDiagnosticsCacheSlotV0>)>> = pool.install(|| {
         pool_items
             .par_iter()
             .map_with(
@@ -392,6 +425,7 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
                     resolver_identity_index.clone(),
                     wave_substrate.clone(),
                     shared_reachability.clone(),
+                    read_set_index.clone(),
                 ),
                 |worker_state, (plan, file)| {
                     if let Some((watch, generation)) = abort
@@ -404,6 +438,7 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
                     let resolver_identity_index = worker_state.2.clone();
                     let wave_substrate = worker_state.3.clone();
                     let shared_reachability = worker_state.4.clone();
+                    let read_set_index = worker_state.5.clone();
                     // A worker panic must not abort the wave: the target drops
                     // out of the result map and the loop recomputes it serially,
                     // panicking exactly where the serial arm would.
@@ -431,10 +466,24 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
                         )
                     }))
                     .ok();
+                    // Attach the declared read-set to the write-behind slot:
+                    // the shard records exactly what this compute could read
+                    // over the committed edge graph.
+                    let slot_with_read_set = value.as_ref().and_then(|_| {
+                        plan.disk_cache_slot.clone().map(|mut slot| {
+                            slot.set_read_set_paths(
+                                omena_query::diagnostics_read_set_for_target_v0(
+                                    read_set_index.as_ref(),
+                                    plan.target_uri.as_str(),
+                                ),
+                            );
+                            slot
+                        })
+                    });
                     if let (Some(sink), Some(value)) = (on_item, value.as_ref()) {
-                        sink(plan.index, value.clone(), plan.disk_cache_slot.clone());
+                        sink(plan.index, value.clone(), slot_with_read_set.clone());
                     }
-                    value
+                    value.map(|value| (value, slot_with_read_set))
                 },
             )
             .collect()
@@ -444,13 +493,19 @@ pub(crate) fn resolved_parallel_style_wave_targets_with_abort_and_sink(
     drop(pool);
     drop(sync);
 
-    for ((plan, _), diagnostics) in pool_items.into_iter().zip(computed) {
-        if let Some(diagnostics) = diagnostics {
+    for ((plan, _), computed_target) in pool_items.into_iter().zip(computed) {
+        if let Some((diagnostics, disk_cache_slot)) = computed_target {
+            if let Some(cached) = plan.oracle_cached_diagnostics.as_ref() {
+                crate::disk_cache::record_disk_diagnostics_cache_oracle_outcome(
+                    plan.target_uri.as_str(),
+                    cached == &diagnostics,
+                );
+            }
             resolved.insert(
                 plan.index,
                 ResolvedParallelStyleTargetV0 {
                     diagnostics,
-                    disk_cache_slot: plan.disk_cache_slot,
+                    disk_cache_slot,
                 },
             );
         }

--- a/rust/crates/omena-lsp-server/src/source_document_cache.rs
+++ b/rust/crates/omena-lsp-server/src/source_document_cache.rs
@@ -16,7 +16,7 @@ const SOURCE_DOCUMENT_INDEX_SCHEMA_VERSION: &str = "0";
 const SOURCE_DOCUMENT_INDEX_SIDECAR_PRODUCT: &str =
     "omena-lsp-server.source-document-index-sidecar";
 const SOURCE_DOCUMENT_INDEX_KEY_PRODUCT: &str = "omena-lsp-server.source-document-index-key";
-const SOURCE_DOCUMENT_INDEX_DIR: &str = "source-document-index-v0";
+const SOURCE_DOCUMENT_INDEX_DIR: &str = "source-document-index-v1";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -51,7 +51,7 @@ pub(crate) fn load_source_document_index_sidecar(
         text_hash,
         resolution_inputs,
     )?;
-    let path = source_document_index_sidecar_path(workspace_folder_uri, key.as_str())?;
+    let path = source_document_index_sidecar_path(workspace_folder_uri, document_uri, language_id)?;
     let bytes = fs::read(path).ok()?;
     let shard: Value = serde_json::from_slice(bytes.as_slice()).ok()?;
     if shard.pointer("/schemaVersion").and_then(Value::as_str)
@@ -99,7 +99,9 @@ pub(crate) fn store_source_document_index_sidecar(
     ) else {
         return;
     };
-    let Some(path) = source_document_index_sidecar_path(workspace_folder_uri, key.as_str()) else {
+    let Some(path) =
+        source_document_index_sidecar_path(workspace_folder_uri, document_uri, language_id)
+    else {
         return;
     };
     let Some(dir) = path.parent() else {
@@ -147,17 +149,8 @@ pub(crate) fn source_document_index_sidecar_file_path_for_test(
     workspace_folder_uri: Option<&str>,
     document_uri: &str,
     language_id: &str,
-    text_hash: &str,
-    resolution_inputs: &OmenaQueryStyleResolutionInputsV0,
 ) -> Option<PathBuf> {
-    let key = source_document_index_key(
-        workspace_folder_uri,
-        document_uri,
-        language_id,
-        text_hash,
-        resolution_inputs,
-    )?;
-    source_document_index_sidecar_path(workspace_folder_uri, key.as_str())
+    source_document_index_sidecar_path(workspace_folder_uri, document_uri, language_id)
 }
 
 fn source_document_index_key(
@@ -187,11 +180,18 @@ fn source_document_index_key(
 
 fn source_document_index_sidecar_path(
     workspace_folder_uri: Option<&str>,
-    key: &str,
+    document_uri: &str,
+    language_id: &str,
 ) -> Option<PathBuf> {
     let workspace_folder_uri = workspace_folder_uri?;
     let root = file_uri_to_path(workspace_folder_uri)?;
-    let hex = key.strip_prefix("blake3:")?;
+    // Stable address (identity, never content): one file per document,
+    // overwritten in place; the content key is a load-verified shard field.
+    let address = crate::disk_cache::stable_cache_shard_address(
+        SOURCE_DOCUMENT_INDEX_SIDECAR_PRODUCT,
+        &[workspace_folder_uri, document_uri, language_id],
+    )?;
+    let hex = address.strip_prefix("blake3:")?.to_string();
     if hex.is_empty() || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
         return None;
     }

--- a/rust/crates/omena-lsp-server/src/source_occurrence_cache.rs
+++ b/rust/crates/omena-lsp-server/src/source_occurrence_cache.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::PathBuf;
 
 const SOURCE_OCCURRENCE_SIDECAR_PRODUCT: &str = "omena-lsp-server.source-occurrence-index-sidecar";
-const SOURCE_OCCURRENCE_SIDECAR_DIR: &str = "source-occurrence-index-v0";
+const SOURCE_OCCURRENCE_SIDECAR_DIR: &str = "source-occurrence-index-v1";
 
 pub(crate) fn store_source_selector_occurrence_sidecar(
     state: &LspShellState,
@@ -20,8 +20,7 @@ pub(crate) fn store_source_selector_occurrence_sidecar(
     let Some(key) = source_occurrence_sidecar_key(workspace_folder_uri, document_keys) else {
         return;
     };
-    let Some(path) = source_occurrence_sidecar_path(state, workspace_folder_uri, key.as_str())
-    else {
+    let Some(path) = source_occurrence_sidecar_path(state, workspace_folder_uri) else {
         return;
     };
     let Some(dir) = path.parent() else {
@@ -78,7 +77,6 @@ fn source_occurrence_sidecar_key(
 fn source_occurrence_sidecar_path(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
-    key: &str,
 ) -> Option<PathBuf> {
     let workspace_folder_uri = workspace_folder_uri?;
     let root = file_uri_to_path(workspace_folder_uri)?;
@@ -90,7 +88,13 @@ fn source_occurrence_sidecar_path(
     {
         return None;
     }
-    let hex = key.strip_prefix("blake3:")?;
+    // Stable address (identity, never content): one file per logical entry,
+    // overwritten in place; the content key is a load-verified shard field.
+    let address = crate::disk_cache::stable_cache_shard_address(
+        SOURCE_OCCURRENCE_SIDECAR_PRODUCT,
+        &[workspace_folder_uri],
+    )?;
+    let hex = address.strip_prefix("blake3:")?.to_string();
     if hex.is_empty() || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
         return None;
     }
@@ -115,8 +119,6 @@ fn source_occurrence_sidecar_digest(value: &Value) -> Option<String> {
 pub(crate) fn source_occurrence_sidecar_file_path_for_test(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
-    document_keys: &[LspSourceSelectorOccurrenceDocumentKey],
 ) -> Option<PathBuf> {
-    let key = source_occurrence_sidecar_key(workspace_folder_uri, document_keys)?;
-    source_occurrence_sidecar_path(state, workspace_folder_uri, key.as_str())
+    source_occurrence_sidecar_path(state, workspace_folder_uri)
 }

--- a/rust/crates/omena-lsp-server/src/source_type_fact_cache.rs
+++ b/rust/crates/omena-lsp-server/src/source_type_fact_cache.rs
@@ -6,14 +6,15 @@ use serde_json::{Value, json};
 use std::{fs, path::PathBuf};
 
 const SOURCE_TYPE_FACT_SIDECAR_PRODUCT: &str = "omena-lsp-server.source-type-fact-sidecar";
-const SOURCE_TYPE_FACT_SIDECAR_DIR: &str = "source-type-fact-cache-v0";
+const SOURCE_TYPE_FACT_SIDECAR_DIR: &str = "source-type-fact-cache-v1";
 
 pub(crate) fn load_source_type_fact_sidecar(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
+    document_uri: &str,
     key: &str,
 ) -> Option<Vec<TsgoTypeFactResultEntryV0>> {
-    let path = source_type_fact_sidecar_path(state, workspace_folder_uri, key)?;
+    let path = source_type_fact_sidecar_path(state, workspace_folder_uri, document_uri)?;
     let bytes = fs::read(path).ok()?;
     let shard: Value = serde_json::from_slice(bytes.as_slice()).ok()?;
     if shard.pointer("/schemaVersion").and_then(Value::as_str) != Some("0")
@@ -35,10 +36,12 @@ pub(crate) fn load_source_type_fact_sidecar(
 pub(crate) fn store_source_type_fact_sidecar(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
+    document_uri: &str,
     key: &str,
     entries: &[TsgoTypeFactResultEntryV0],
 ) {
-    let Some(path) = source_type_fact_sidecar_path(state, workspace_folder_uri, key) else {
+    let Some(path) = source_type_fact_sidecar_path(state, workspace_folder_uri, document_uri)
+    else {
         return;
     };
     let Some(dir) = path.parent() else {
@@ -75,7 +78,7 @@ pub(crate) fn store_source_type_fact_sidecar(
 fn source_type_fact_sidecar_path(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
-    key: &str,
+    document_uri: &str,
 ) -> Option<PathBuf> {
     let workspace_folder_uri = workspace_folder_uri?;
     let root = file_uri_to_path(workspace_folder_uri)?;
@@ -87,7 +90,13 @@ fn source_type_fact_sidecar_path(
     {
         return None;
     }
-    let hex = key.strip_prefix("blake3:")?;
+    // Stable address (identity, never content): one file per document,
+    // overwritten in place; the content key is a load-verified shard field.
+    let address = crate::disk_cache::stable_cache_shard_address(
+        SOURCE_TYPE_FACT_SIDECAR_PRODUCT,
+        &[workspace_folder_uri, document_uri],
+    )?;
+    let hex = address.strip_prefix("blake3:")?.to_string();
     if hex.is_empty() || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
         return None;
     }
@@ -151,7 +160,7 @@ fn source_type_fact_resolved_type_from_value(value: &Value) -> Option<TsgoResolv
 pub(crate) fn source_type_fact_sidecar_file_path_for_test(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
-    key: &str,
+    document_uri: &str,
 ) -> Option<PathBuf> {
-    source_type_fact_sidecar_path(state, workspace_folder_uri, key)
+    source_type_fact_sidecar_path(state, workspace_folder_uri, document_uri)
 }

--- a/rust/crates/omena-lsp-server/src/source_type_facts.rs
+++ b/rust/crates/omena-lsp-server/src/source_type_facts.rs
@@ -69,8 +69,13 @@ pub(crate) fn refresh_source_type_fact_candidates_for_document(
         return;
     }
     if let Some((cache_key, entries)) = cache_key.as_ref().and_then(|key| {
-        load_source_type_fact_sidecar(state, document.workspace_folder_uri.as_deref(), key)
-            .map(|entries| (key.clone(), entries))
+        load_source_type_fact_sidecar(
+            state,
+            document.workspace_folder_uri.as_deref(),
+            document.uri.as_str(),
+            key,
+        )
+        .map(|entries| (key.clone(), entries))
     }) {
         state
             .source_type_fact_cache
@@ -125,6 +130,7 @@ pub(crate) fn refresh_source_type_fact_candidates_for_document(
         store_source_type_fact_sidecar(
             state,
             document.workspace_folder_uri.as_deref(),
+            document.uri.as_str(),
             cache_key.as_str(),
             entries.as_slice(),
         );
@@ -768,6 +774,7 @@ export function Badge({ size }: BadgeProps) {
         crate::source_type_fact_cache::store_source_type_fact_sidecar(
             &state,
             Some(workspace_uri.as_str()),
+            source_uri.as_str(),
             cache_key.as_str(),
             &[entry],
         );
@@ -775,7 +782,7 @@ export function Badge({ size }: BadgeProps) {
             crate::source_type_fact_cache::source_type_fact_sidecar_file_path_for_test(
                 &state,
                 Some(workspace_uri.as_str()),
-                cache_key.as_str(),
+                source_uri.as_str(),
             )
             .ok_or_else(|| std::io::Error::other("source type fact sidecar path should resolve"))?;
         assert!(
@@ -938,6 +945,7 @@ export function Badge({ size }: BadgeProps) {
         crate::source_type_fact_cache::store_source_type_fact_sidecar(
             &state,
             Some(workspace_uri.as_str()),
+            source_uri.as_str(),
             cache_key.as_str(),
             &[resolved_entry],
         );
@@ -964,6 +972,7 @@ export function Badge({ size }: BadgeProps) {
         crate::source_type_fact_cache::store_source_type_fact_sidecar(
             &state,
             Some(workspace_uri.as_str()),
+            source_uri.as_str(),
             cache_key.as_str(),
             std::slice::from_ref(&unresolved_entry),
         );

--- a/rust/crates/omena-lsp-server/src/state.rs
+++ b/rust/crates/omena-lsp-server/src/state.rs
@@ -337,8 +337,8 @@ pub struct LspShellState {
     /// demands; the gates decide when a flush happens. These replace the
     /// dirty/owed flags and the per-subsystem refresh revision.
     pub(crate) tide_ledger: crate::tide::TideEpochLedgerV0,
-    pub(crate) tide_sif_lane: crate::tide::TideLaneV0,
-    pub(crate) tide_republish_lane: crate::tide::TideLaneV0,
+    pub(crate) tide_sif_lane: crate::tide::TideLaneV0<crate::tide::TideSifDemandV0>,
+    pub(crate) tide_republish_lane: crate::tide::TideLaneV0<crate::tide::TideRepublishDemandV0>,
     /// Executor-visible generation watch for the republish lane: flushes
     /// store their generation, window reopens bump it, and the off-loop wave
     /// compares it at item boundaries to abort disowned tides (rfcs#111).

--- a/rust/crates/omena-lsp-server/src/state.rs
+++ b/rust/crates/omena-lsp-server/src/state.rs
@@ -302,6 +302,10 @@ pub(crate) struct LspWorkspaceOccurrenceIndexMemo {
 pub(crate) struct LspReverseDependencyIndexMemo {
     pub(crate) revision: u64,
     pub(crate) summary_hash: String,
+    /// Tide-ledger epoch at the last refresh: consumers that would GUESS
+    /// from a stale graph (cone seeding) compare this against the corpus
+    /// input marks and widen instead.
+    pub(crate) ledger_epoch: u64,
     pub(crate) index: ReverseDependencyIndexV0,
 }
 
@@ -562,6 +566,13 @@ impl LspShellState {
     /// apply batches against it to drop disowned tides (rfcs#111 §9.4).
     pub fn tide_republish_lane_generation(&self) -> u64 {
         self.tide_republish_lane.generation()
+    }
+
+    /// Whether a republish tide is in flight — the runtime loop's pump must
+    /// keep this held until the stream's FINAL chunk drains (completing on a
+    /// momentarily-empty queue would disable disown/abort/carry-over).
+    pub fn tide_republish_lane_in_flight(&self) -> bool {
+        self.tide_republish_lane.in_flight()
     }
 
     /// Advance the Tide tick — called once per runtime loop iteration; the

--- a/rust/crates/omena-lsp-server/src/style_diagnostics.rs
+++ b/rust/crates/omena-lsp-server/src/style_diagnostics.rs
@@ -44,23 +44,34 @@ pub(crate) fn resolve_style_diagnostics_for_uri(
     // path does — otherwise an alias import dims every selector as `unusedSelector`.
     let resolution_inputs =
         resolution_inputs_for_workspace_uri(state, document.workspace_folder_uri.as_deref());
-    // RFC 0009 Pillar C (rfcs#66) stage 1: the persistent content-addressed
-    // shard cache. The composite key chains the FULL input surface gathered
-    // above (target path, every style source, every source document, package
-    // manifests, external SIFs, resolution inputs, diagnostics settings) plus
-    // crate/schema/arm versions, so a shard can only serve when a recompute
-    // would be byte-identical by construction. Misses fall through to the
-    // compute below and persist write-behind; everything is fail-soft and
-    // killable via OMENA_LSP_DISK_CACHE=off.
-    let disk_cache_slot = disk_diagnostics_cache_slot_for_resolve(
-        state,
-        document.workspace_folder_uri.as_deref(),
-        document.uri.as_str(),
-        style_sources.as_slice(),
-        source_documents.as_slice(),
-        external_sifs,
-        &resolution_inputs,
+    // RFC 0009 Pillar C (rfcs#66) stage 2: the persistent verifying-trace
+    // shard cache. The shard sits at a stable per-target address and records
+    // the read-set its compute declared; `load` verifies the recorded
+    // dependencies' content hashes plus an environment fingerprint against
+    // the surface gathered above, so a hit survives edits outside the
+    // target's dependency cone and stays byte-identical to a recompute by
+    // the depfile argument. Misses fall through to the compute below and
+    // persist write-behind; everything is fail-soft and killable via
+    // OMENA_LSP_DISK_CACHE=off.
+    let disk_cache_plan = crate::disk_cache::disk_diagnostics_cache_wave_plan_v1(
+        &crate::disk_cache::DiskDiagnosticsCacheEnvironmentComponentsV1 {
+            style_sources: style_sources.as_slice(),
+            source_documents: source_documents.as_slice(),
+            package_manifests: state.resolution.package_manifests.as_slice(),
+            external_sifs,
+            resolution_inputs: &resolution_inputs,
+            severity: state.diagnostics.severity,
+            deep_analysis: state.diagnostics.deep_analysis,
+        },
     );
+    let disk_cache_slot = disk_cache_plan.as_ref().and_then(|plan| {
+        disk_diagnostics_cache_slot_for_resolve(
+            state,
+            document.workspace_folder_uri.as_deref(),
+            document.uri.as_str(),
+            plan,
+        )
+    });
     if let Some(cached_diagnostics) = disk_cache_slot.as_ref().and_then(|slot| slot.load()) {
         return cached_diagnostics;
     }
@@ -115,9 +126,21 @@ pub(crate) fn resolve_style_diagnostics_for_uri(
         workspace_diagnostics_summary,
         committed_cross_file_summary.as_ref(),
     );
-    // RFC 0009 Pillar C (rfcs#66): write-behind after the compute. Fail-soft —
-    // io errors are swallowed and a session breaker stops retrying hot.
-    if let Some(slot) = disk_cache_slot.as_ref() {
+    // RFC 0009 Pillar C (rfcs#66): write-behind after the compute, carrying
+    // the read-set declared over the committed summary's edges. Without a
+    // summary (the straight-line arm) there is no sound manifest, so nothing
+    // is stored — fail-soft, not fail-broad. Io errors are swallowed and a
+    // session breaker stops retrying hot.
+    if let (Some(slot), Some(summary)) =
+        (disk_cache_slot, committed_cross_file_summary.as_ref())
+    {
+        let mut slot = slot;
+        let read_set_index =
+            omena_query::reverse_dependency_index_from_edges_v0(summary.edges.as_slice());
+        slot.set_read_set_paths(omena_query::diagnostics_read_set_for_target_v0(
+            &read_set_index,
+            document.uri.as_str(),
+        ));
         slot.store_write_behind(state, &diagnostics);
     }
     diagnostics

--- a/rust/crates/omena-lsp-server/src/style_diagnostics.rs
+++ b/rust/crates/omena-lsp-server/src/style_diagnostics.rs
@@ -44,8 +44,7 @@ pub(crate) fn resolve_style_diagnostics_for_uri(
     // path does — otherwise an alias import dims every selector as `unusedSelector`.
     let resolution_inputs =
         resolution_inputs_for_workspace_uri(state, document.workspace_folder_uri.as_deref());
-    // RFC 0009 Pillar C (rfcs#66) stage 2: the verifying-trace shard cache —
-    // a hit survives edits outside the target's cone (see disk_cache.rs).
+    // RFC 0009 Pillar C (rfcs#66) stage 2 verifying-trace cache (disk_cache.rs).
     let disk_cache_slot = crate::disk_cache::disk_diagnostics_cache_slot_for_serial_resolve(
         state,
         document.workspace_folder_uri.as_deref(),

--- a/rust/crates/omena-lsp-server/src/style_diagnostics.rs
+++ b/rust/crates/omena-lsp-server/src/style_diagnostics.rs
@@ -44,16 +44,12 @@ pub(crate) fn resolve_style_diagnostics_for_uri(
     // path does — otherwise an alias import dims every selector as `unusedSelector`.
     let resolution_inputs =
         resolution_inputs_for_workspace_uri(state, document.workspace_folder_uri.as_deref());
-    // RFC 0009 Pillar C (rfcs#66) stage 2: the persistent verifying-trace
-    // shard cache. The shard sits at a stable per-target address and records
-    // the read-set its compute declared; `load` verifies the recorded
-    // dependencies' content hashes plus an environment fingerprint against
-    // the surface gathered above, so a hit survives edits outside the
-    // target's dependency cone and stays byte-identical to a recompute by
-    // the depfile argument. Misses fall through to the compute below and
-    // persist write-behind; everything is fail-soft and killable via
-    // OMENA_LSP_DISK_CACHE=off.
-    let disk_cache_plan = crate::disk_cache::disk_diagnostics_cache_wave_plan_v1(
+    // RFC 0009 Pillar C (rfcs#66) stage 2: the verifying-trace shard cache —
+    // a hit survives edits outside the target's cone (see disk_cache.rs).
+    let disk_cache_slot = crate::disk_cache::disk_diagnostics_cache_slot_for_serial_resolve(
+        state,
+        document.workspace_folder_uri.as_deref(),
+        document.uri.as_str(),
         &crate::disk_cache::DiskDiagnosticsCacheEnvironmentComponentsV1 {
             style_sources: style_sources.as_slice(),
             source_documents: source_documents.as_slice(),
@@ -64,14 +60,6 @@ pub(crate) fn resolve_style_diagnostics_for_uri(
             deep_analysis: state.diagnostics.deep_analysis,
         },
     );
-    let disk_cache_slot = disk_cache_plan.as_ref().and_then(|plan| {
-        disk_diagnostics_cache_slot_for_resolve(
-            state,
-            document.workspace_folder_uri.as_deref(),
-            document.uri.as_str(),
-            plan,
-        )
-    });
     if let Some(cached_diagnostics) = disk_cache_slot.as_ref().and_then(|slot| slot.load()) {
         return cached_diagnostics;
     }
@@ -127,22 +115,14 @@ pub(crate) fn resolve_style_diagnostics_for_uri(
         committed_cross_file_summary.as_ref(),
     );
     // RFC 0009 Pillar C (rfcs#66): write-behind after the compute, carrying
-    // the read-set declared over the committed summary's edges. Without a
-    // summary (the straight-line arm) there is no sound manifest, so nothing
-    // is stored — fail-soft, not fail-broad. Io errors are swallowed and a
-    // session breaker stops retrying hot.
-    if let (Some(slot), Some(summary)) =
-        (disk_cache_slot, committed_cross_file_summary.as_ref())
-    {
-        let mut slot = slot;
-        let read_set_index =
-            omena_query::reverse_dependency_index_from_edges_v0(summary.edges.as_slice());
-        slot.set_read_set_paths(omena_query::diagnostics_read_set_for_target_v0(
-            &read_set_index,
-            document.uri.as_str(),
-        ));
-        slot.store_write_behind(state, &diagnostics);
-    }
+    // the read-set declared over the committed summary's edges.
+    crate::disk_cache::store_disk_diagnostics_shard_for_serial_resolve(
+        state,
+        disk_cache_slot,
+        committed_cross_file_summary.as_ref(),
+        document.uri.as_str(),
+        &diagnostics,
+    );
     diagnostics
 }
 

--- a/rust/crates/omena-lsp-server/src/style_symbol_occurrence_cache.rs
+++ b/rust/crates/omena-lsp-server/src/style_symbol_occurrence_cache.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 const STYLE_SYMBOL_OCCURRENCE_SIDECAR_PRODUCT: &str =
     "omena-lsp-server.style-symbol-occurrence-index-sidecar";
-const STYLE_SYMBOL_OCCURRENCE_SIDECAR_DIR: &str = "style-symbol-occurrence-index-v0";
+const STYLE_SYMBOL_OCCURRENCE_SIDECAR_DIR: &str = "style-symbol-occurrence-index-v1";
 
 pub(crate) fn store_style_symbol_occurrence_sidecar(
     state: &LspShellState,
@@ -20,9 +20,7 @@ pub(crate) fn store_style_symbol_occurrence_sidecar(
     let Some(key) = style_symbol_occurrence_sidecar_key(workspace_folder_uri, document_keys) else {
         return;
     };
-    let Some(path) =
-        style_symbol_occurrence_sidecar_path(state, workspace_folder_uri, key.as_str())
-    else {
+    let Some(path) = style_symbol_occurrence_sidecar_path(state, workspace_folder_uri) else {
         return;
     };
     let Some(dir) = path.parent() else {
@@ -84,7 +82,6 @@ fn style_symbol_occurrence_sidecar_key(
 fn style_symbol_occurrence_sidecar_path(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
-    key: &str,
 ) -> Option<PathBuf> {
     let workspace_folder_uri = workspace_folder_uri?;
     let root = file_uri_to_path(workspace_folder_uri)?;
@@ -96,7 +93,13 @@ fn style_symbol_occurrence_sidecar_path(
     {
         return None;
     }
-    let hex = key.strip_prefix("blake3:")?;
+    // Stable address (identity, never content): one file per logical entry,
+    // overwritten in place; the content key is a load-verified shard field.
+    let address = crate::disk_cache::stable_cache_shard_address(
+        STYLE_SYMBOL_OCCURRENCE_SIDECAR_PRODUCT,
+        &[workspace_folder_uri],
+    )?;
+    let hex = address.strip_prefix("blake3:")?.to_string();
     if hex.is_empty() || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
         return None;
     }
@@ -121,8 +124,6 @@ fn style_symbol_occurrence_sidecar_digest(value: &Value) -> Option<String> {
 pub(crate) fn style_symbol_occurrence_sidecar_file_path_for_test(
     state: &LspShellState,
     workspace_folder_uri: Option<&str>,
-    document_keys: &[LspSourceSelectorOccurrenceDocumentKey],
 ) -> Option<PathBuf> {
-    let key = style_symbol_occurrence_sidecar_key(workspace_folder_uri, document_keys)?;
-    style_symbol_occurrence_sidecar_path(state, workspace_folder_uri, key.as_str())
+    style_symbol_occurrence_sidecar_path(state, workspace_folder_uri)
 }

--- a/rust/crates/omena-lsp-server/src/tests/disk_cache.rs
+++ b/rust/crates/omena-lsp-server/src/tests/disk_cache.rs
@@ -86,7 +86,7 @@ fn run_disk_cache_session(
 }
 
 fn disk_cache_dir(workspace_root: &Path) -> PathBuf {
-    workspace_root.join(".cache/omena/diagnostics-cache-v0")
+    workspace_root.join(".cache/omena/diagnostics-cache-v1")
 }
 
 fn shard_files(cache_dir: &Path) -> Vec<PathBuf> {
@@ -133,7 +133,8 @@ fn outputs_contain_diagnostic_code(outputs: &[ScheduledLspOutput], code: &str) -
 }
 
 #[test]
-fn disk_cache_key_includes_style_resolution_disk_identity_snapshot() {
+fn disk_cache_environment_fingerprint_includes_style_resolution_disk_identity_snapshot()
+-> Result<(), &'static str> {
     let style_sources = vec![OmenaQueryStyleSourceInputV0 {
         style_path: "file:///workspace/src/App.module.scss".to_string(),
         style_source: "@use \"@styles/tokens\";".to_string(),
@@ -152,32 +153,26 @@ fn disk_cache_key_includes_style_resolution_disk_identity_snapshot() {
         ..Default::default()
     };
 
-    let base_key = crate::disk_cache::disk_diagnostics_cache_key_v0(
-        &crate::disk_cache::DiskDiagnosticsCacheKeyComponentsV0 {
-            target_style_path: "file:///workspace/src/App.module.scss",
-            style_sources: style_sources.as_slice(),
-            source_documents: source_documents.as_slice(),
-            package_manifests: package_manifests.as_slice(),
-            external_sifs: external_sifs.as_slice(),
-            resolution_inputs: &base_inputs,
-            severity: 2,
-            deep_analysis: false,
-        },
+    let plan_for = |resolution_inputs: &omena_query::OmenaQueryStyleResolutionInputsV0| {
+        crate::disk_cache::disk_diagnostics_cache_wave_plan_v1(
+            &crate::disk_cache::DiskDiagnosticsCacheEnvironmentComponentsV1 {
+                style_sources: style_sources.as_slice(),
+                source_documents: source_documents.as_slice(),
+                package_manifests: package_manifests.as_slice(),
+                external_sifs: external_sifs.as_slice(),
+                resolution_inputs,
+                severity: 2,
+                deep_analysis: false,
+            },
+        )
+    };
+    let base_plan = plan_for(&base_inputs).ok_or("base plan")?;
+    let disk_backed_plan = plan_for(&disk_backed_inputs).ok_or("disk-backed plan")?;
+    assert_ne!(
+        base_plan.environment_fingerprint_for_test(),
+        disk_backed_plan.environment_fingerprint_for_test(),
     );
-    let disk_backed_key = crate::disk_cache::disk_diagnostics_cache_key_v0(
-        &crate::disk_cache::DiskDiagnosticsCacheKeyComponentsV0 {
-            target_style_path: "file:///workspace/src/App.module.scss",
-            style_sources: style_sources.as_slice(),
-            source_documents: source_documents.as_slice(),
-            package_manifests: package_manifests.as_slice(),
-            external_sifs: external_sifs.as_slice(),
-            resolution_inputs: &disk_backed_inputs,
-            severity: 2,
-            deep_analysis: false,
-        },
-    );
-
-    assert_ne!(base_key, disk_backed_key);
+    Ok(())
 }
 
 #[test]
@@ -323,9 +318,10 @@ fn edited_document_text_misses_the_shard_and_recomputes() -> Result<(), String> 
         serde_json::to_vec(&shard).map_err(|error| format!("serialize tampered: {error}"))?;
     std::fs::write(shard_path, tampered).map_err(|error| format!("write tampered: {error}"))?;
 
-    // Different buffer text => different composite key => the tampered shard
-    // must be ignored and the diagnostics recomputed (and written as a NEW
-    // shard alongside the old one).
+    // Different buffer text => the recorded target dependency's content hash
+    // no longer verifies => the tampered shard must be ignored, the
+    // diagnostics recomputed, and the SAME stable address overwritten in
+    // place (stage 2: one shard per target, no accumulation).
     let edited_text = ":root { --brand: red; }\n.btn { width: var(--missing); }";
     let outputs = run_disk_cache_session(workspace_uri.as_str(), style_uri.as_str(), edited_text);
     assert!(
@@ -338,8 +334,8 @@ fn edited_document_text_misses_the_shard_and_recomputes() -> Result<(), String> 
     );
     assert_eq!(
         shard_files(&cache_dir).len(),
-        2,
-        "the recompute must write-behind a second shard",
+        1,
+        "the recompute must overwrite the target's single shard in place",
     );
     Ok(())
 }

--- a/rust/crates/omena-lsp-server/src/tests/sass_resolution_package.rs
+++ b/rust/crates/omena-lsp-server/src/tests/sass_resolution_package.rs
@@ -1409,12 +1409,10 @@ fn assert_foreign_occurrence_artifacts_are_workspace_cache_confined(
     let workspace_root = file_uri_to_path(workspace_uri)
         .ok_or_else(|| std::io::Error::other("workspace URI should map to a file path"))?;
     let workspace_cache_root = workspace_root.join(".cache").join("omena");
-    let document_keys = style_symbol_occurrence_document_keys(state, Some(workspace_uri));
     let sidecar_path =
         crate::style_symbol_occurrence_cache::style_symbol_occurrence_sidecar_file_path_for_test(
             state,
             Some(workspace_uri),
-            document_keys.as_slice(),
         )
         .ok_or_else(|| {
             std::io::Error::other("style symbol occurrence sidecar path should resolve")
@@ -1429,7 +1427,7 @@ fn assert_foreign_occurrence_artifacts_are_workspace_cache_confined(
     );
     assert!(
         workspace_cache_root
-            .join("workspace-occurrence-shards-v0")
+            .join("workspace-occurrence-shards-v1")
             .exists(),
         "foreign occurrence shards should be persisted below the workspace cache root"
     );

--- a/rust/crates/omena-lsp-server/src/tests/tide_kernel.rs
+++ b/rust/crates/omena-lsp-server/src/tests/tide_kernel.rs
@@ -1,11 +1,12 @@
 //! Property harness for the Tide kernel: synthetic event streams drive the
-//! lane/ledger and machine-check the invariants I1, I5, and the
-//! footprint-validity rule against an independent model. The oracle exists
-//! before the wiring it gates.
+//! lane/ledger and machine-check the invariants I1, I5, the footprint-
+//! validity rule, and the per-epoch demand-lattice laws (join monotonicity,
+//! deposit-order confluence, disown carry-over conservation) against an
+//! independent model. The oracle exists before the wiring it gates.
 
 use crate::tide::{
-    TideDemandV0, TideEpochLedgerV0, TideFootprintV0, TideGateInputsV0, TideInputKindV0,
-    TideLaneConfigV0, TideLaneV0, tide_may_publish,
+    TideDemandJoinV0, TideEpochLedgerV0, TideFootprintV0, TideGateInputsV0, TideInputKindV0,
+    TideLaneConfigV0, TideLaneV0, TideRepublishDemandV0, tide_may_publish,
 };
 use std::collections::BTreeSet;
 
@@ -80,6 +81,99 @@ fn footprint_validity_matches_model_under_random_advances() {
     }
 }
 
+fn random_republish_demand(rng: &mut XorShift64) -> TideRepublishDemandV0 {
+    match rng.below(5) {
+        0 => TideRepublishDemandV0::All,
+        _ => {
+            let seeds = ["a", "b", "c", "d"];
+            let mut set = BTreeSet::new();
+            for seed in seeds {
+                if rng.below(2) == 0 {
+                    set.insert(seed.to_string());
+                }
+            }
+            TideRepublishDemandV0::cone(set)
+        }
+    }
+}
+
+#[test]
+fn republish_demand_join_is_a_join_semilattice() {
+    let mut rng = XorShift64(0x51ED_2701_9E11_77D3);
+    for _ in 0..2_000 {
+        let a = random_republish_demand(&mut rng);
+        let b = random_republish_demand(&mut rng);
+        let c = random_republish_demand(&mut rng);
+
+        // Idempotent.
+        let mut aa = a.clone();
+        aa.join(a.clone());
+        assert_eq!(aa, a, "join must be idempotent");
+        // Commutative.
+        let mut ab = a.clone();
+        ab.join(b.clone());
+        let mut ba = b.clone();
+        ba.join(a.clone());
+        assert_eq!(ab, ba, "join must be commutative");
+        // Associative.
+        let mut ab_c = ab.clone();
+        ab_c.join(c.clone());
+        let mut bc = b.clone();
+        bc.join(c.clone());
+        let mut a_bc = a.clone();
+        a_bc.join(bc);
+        assert_eq!(ab_c, a_bc, "join must be associative");
+        // Bottom is the identity.
+        let mut a_bottom = a.clone();
+        a_bottom.join(TideRepublishDemandV0::bottom());
+        assert_eq!(a_bottom, a, "bottom must be the join identity");
+    }
+}
+
+#[test]
+fn deposit_order_is_confluent() {
+    // LVars determinism (Kuper & Newton, FHPC 2013): monotone joins make the
+    // settled value independent of deposit interleaving.
+    let mut rng = XorShift64(0xC0FF_EE00_1234_5678);
+    let config = TideLaneConfigV0 {
+        aging_bound_ticks: 10,
+    };
+    let open_idle = TideGateInputsV0 {
+        frontier_passed: true,
+        idle: true,
+    };
+    for _ in 0..200 {
+        let deposits: Vec<TideRepublishDemandV0> =
+            (0..4).map(|_| random_republish_demand(&mut rng)).collect();
+        let mut expected = TideRepublishDemandV0::bottom();
+        for deposit in &deposits {
+            expected.join(deposit.clone());
+        }
+        // Two independently shuffled orders of the same multiset.
+        for _ in 0..2 {
+            let mut order: Vec<usize> = (0..deposits.len()).collect();
+            for index in (1..order.len()).rev() {
+                let swap = rng.below(index as u64 + 1) as usize;
+                order.swap(index, swap);
+            }
+            let mut lane = TideLaneV0::<TideRepublishDemandV0>::default();
+            for position in &order {
+                lane.deposit(deposits[*position].clone(), 0);
+            }
+            match lane.try_flush(open_idle, 1, &config) {
+                Some(flush) => assert_eq!(
+                    flush.demand, expected,
+                    "flushed join must be order-independent"
+                ),
+                None => assert!(
+                    expected.is_bottom(),
+                    "a non-bottom joined deposit set must flush"
+                ),
+            }
+        }
+    }
+}
+
 #[test]
 fn lane_invariants_hold_under_random_event_streams() {
     let config = TideLaneConfigV0 {
@@ -87,19 +181,16 @@ fn lane_invariants_hold_under_random_event_streams() {
     };
     for seed in 1..=50u64 {
         let mut rng = XorShift64(seed.wrapping_mul(0x2545_F491_4F6C_DD1D));
-        let mut lane = TideLaneV0::default();
-        let mut model_demands: BTreeSet<TideDemandV0> = BTreeSet::new();
-        let mut model_in_flight = false;
+        let mut lane = TideLaneV0::<TideRepublishDemandV0>::default();
+        // Model: the accumulated window value and the frozen in-flight value.
+        let mut model_window = TideRepublishDemandV0::bottom();
+        let mut model_in_flight: Option<TideRepublishDemandV0> = None;
         for tick in 0..3_000u64 {
             match rng.below(6) {
                 0 | 1 => {
-                    let demand = if rng.below(2) == 0 {
-                        TideDemandV0::SifRefresh
-                    } else {
-                        TideDemandV0::WorkspaceRepublish
-                    };
+                    let demand = random_republish_demand(&mut rng);
                     lane.deposit(demand.clone(), tick);
-                    model_demands.insert(demand);
+                    model_window.join(demand);
                 }
                 2 | 3 => {
                     let inputs = TideGateInputsV0 {
@@ -111,14 +202,16 @@ fn lane_invariants_hold_under_random_event_streams() {
                         Some(flush) => {
                             // I5: aging never satisfies the correctness layer.
                             assert!(inputs.frontier_passed, "flush behind a closed frontier");
-                            // I1: one in-flight tide per lane; never from empty.
-                            assert!(!model_in_flight, "second concurrent tide");
-                            assert!(!model_demands.is_empty(), "flush from an empty lane");
-                            let drained: Vec<_> = model_demands.iter().cloned().collect();
-                            assert_eq!(flush.demands, drained, "flush must drain everything");
+                            // I1: one in-flight tide per lane; never from bottom.
+                            assert!(model_in_flight.is_none(), "second concurrent tide");
+                            assert!(!model_window.is_bottom(), "flush from a bottom lane");
+                            // The flush freezes exactly the window's join.
+                            assert_eq!(flush.demand, model_window, "flush must drain the join");
                             assert_eq!(flush.generation, lane.generation());
-                            model_demands.clear();
-                            model_in_flight = true;
+                            model_in_flight = Some(std::mem::replace(
+                                &mut model_window,
+                                TideRepublishDemandV0::bottom(),
+                            ));
                         }
                         None => {
                             if lane.starvation_alarm_count() > alarms_before {
@@ -139,17 +232,18 @@ fn lane_invariants_hold_under_random_event_streams() {
                     };
                     let matches_current = generation == lane.generation();
                     lane.tide_completed(generation);
-                    if matches_current && model_in_flight {
-                        model_in_flight = false;
+                    if matches_current && model_in_flight.is_some() {
+                        model_in_flight = None;
                     }
                 }
                 _ => {
                     let generation_before = lane.generation();
                     let generation_after = lane.reopen_window();
-                    if model_in_flight {
-                        // rfcs#111 §9.4: the running tide is disowned.
+                    if let Some(disowned) = model_in_flight.take() {
+                        // rfcs#111 §9.4 + per-epoch carry-over: the running
+                        // tide is disowned AND its coverage is owed again.
                         assert_eq!(generation_after, generation_before + 1);
-                        model_in_flight = false;
+                        model_window.join(disowned);
                     } else {
                         assert_eq!(generation_after, generation_before);
                     }
@@ -157,11 +251,80 @@ fn lane_invariants_hold_under_random_event_streams() {
             }
             assert_eq!(
                 lane.in_flight(),
-                model_in_flight,
+                model_in_flight.is_some(),
                 "in-flight model diverged"
+            );
+            assert_eq!(
+                lane.has_demand(),
+                !model_window.is_bottom(),
+                "window-value model diverged"
             );
         }
     }
+}
+
+#[test]
+fn disowned_demand_carries_over_into_the_new_window() -> Result<(), &'static str> {
+    let config = TideLaneConfigV0 {
+        aging_bound_ticks: 10,
+    };
+    let open_idle = TideGateInputsV0 {
+        frontier_passed: true,
+        idle: true,
+    };
+    let mut lane = TideLaneV0::<TideRepublishDemandV0>::default();
+    lane.deposit(
+        TideRepublishDemandV0::cone([String::from("a"), String::from("b")]),
+        0,
+    );
+    let flush = lane.try_flush(open_idle, 1, &config).ok_or("first flush")?;
+
+    // The window reopens mid-tide; a new smaller cone arrives.
+    lane.reopen_window();
+    lane.deposit(TideRepublishDemandV0::cone([String::from("c")]), 2);
+    // The stale completion must not discharge the carried demand.
+    lane.tide_completed(flush.generation);
+
+    let carried = lane
+        .try_flush(open_idle, 3, &config)
+        .ok_or("carry-over flush")?;
+    assert_eq!(
+        carried.demand,
+        TideRepublishDemandV0::cone([String::from("a"), String::from("b"), String::from("c")]),
+        "the disowned tide's coverage must be owed again, joined with new deposits"
+    );
+    Ok(())
+}
+
+#[test]
+fn carried_over_demand_keeps_its_deposit_age() -> Result<(), &'static str> {
+    let config = TideLaneConfigV0 {
+        aging_bound_ticks: 10,
+    };
+    let open_idle = TideGateInputsV0 {
+        frontier_passed: true,
+        idle: true,
+    };
+    let open_busy = TideGateInputsV0 {
+        frontier_passed: true,
+        idle: false,
+    };
+    let mut lane = TideLaneV0::<TideRepublishDemandV0>::default();
+    lane.deposit(TideRepublishDemandV0::All, 0);
+    let _flush = lane.try_flush(open_idle, 1, &config).ok_or("flush")?;
+    lane.reopen_window();
+    // The carried demand is as old as its ORIGINAL deposit (tick 0), so at
+    // tick 11 aging already overrides courtesy — it neither restarts young
+    // nor pretends to be older than it is.
+    assert!(
+        lane.try_flush(open_busy, 5, &config).is_none(),
+        "not yet aged at tick 5"
+    );
+    assert!(
+        lane.try_flush(open_busy, 11, &config).is_some(),
+        "aged out of courtesy by tick 11 measured from the original deposit"
+    );
+    Ok(())
 }
 
 #[test]
@@ -169,8 +332,8 @@ fn aging_overrides_courtesy_but_never_correctness() -> Result<(), &'static str> 
     let config = TideLaneConfigV0 {
         aging_bound_ticks: 10,
     };
-    let mut lane = TideLaneV0::default();
-    lane.deposit(TideDemandV0::WorkspaceRepublish, 0);
+    let mut lane = TideLaneV0::<TideRepublishDemandV0>::default();
+    lane.deposit(TideRepublishDemandV0::All, 0);
 
     // Aged demand behind a CLOSED frontier: no flush, one alarm per window.
     let closed = TideGateInputsV0 {
@@ -194,11 +357,11 @@ fn aging_overrides_courtesy_but_never_correctness() -> Result<(), &'static str> 
     let flush = lane
         .try_flush(open_busy, 17, &config)
         .ok_or("aged demand must flush once the frontier passes")?;
-    assert_eq!(flush.demands, vec![TideDemandV0::WorkspaceRepublish]);
+    assert_eq!(flush.demand, TideRepublishDemandV0::All);
 
     // A fresh demand while busy: courtesy holds it back until idle or aged.
     lane.tide_completed(flush.generation);
-    lane.deposit(TideDemandV0::WorkspaceRepublish, 20);
+    lane.deposit(TideRepublishDemandV0::All, 20);
     assert!(lane.try_flush(open_busy, 21, &config).is_none());
     let open_idle = TideGateInputsV0 {
         frontier_passed: true,
@@ -217,23 +380,24 @@ fn one_flush_per_window_and_deposit_idempotence() -> Result<(), &'static str> {
         frontier_passed: true,
         idle: true,
     };
-    let mut lane = TideLaneV0::default();
-    assert!(lane.deposit(TideDemandV0::SifRefresh, 0));
+    let mut lane = TideLaneV0::<TideRepublishDemandV0>::default();
+    let cone = TideRepublishDemandV0::cone([String::from("a")]);
+    assert!(lane.deposit(cone.clone(), 0));
     assert!(
-        !lane.deposit(TideDemandV0::SifRefresh, 1),
-        "deposits are idempotent"
+        !lane.deposit(cone.clone(), 1),
+        "joining an already-held value must report no growth"
     );
 
     let flush = lane
         .try_flush(open_idle, 2, &config)
         .ok_or("gate must open")?;
-    assert_eq!(flush.demands, vec![TideDemandV0::SifRefresh]);
+    assert_eq!(flush.demand, cone);
     // I1: no second flush while the tide is in flight, even with demand.
-    lane.deposit(TideDemandV0::SifRefresh, 3);
+    lane.deposit(TideRepublishDemandV0::All, 3);
     assert!(lane.try_flush(open_idle, 4, &config).is_none());
     lane.tide_completed(flush.generation);
     assert!(lane.try_flush(open_idle, 5, &config).is_some());
-    // Empty lane never flushes.
+    // Bottom lane never flushes.
     assert!(lane.try_flush(open_idle, 6, &config).is_none());
     Ok(())
 }

--- a/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
+++ b/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
@@ -1,9 +1,11 @@
 //! Tide executor round-trip tests: prepare → collect → apply → complete
 //! against a real two-document corpus, plus the disowned-tide path where a
-//! window reopen drops the pending applies.
+//! window reopen drops the pending applies, plus demand-lattice targeting
+//! (a cone flush covers the seeds' reverse-dependency closure, not the
+//! corpus).
 
 use super::handle_lsp_message;
-use crate::tide::TideDemandV0;
+use crate::tide::TideRepublishDemandV0;
 use crate::{
     LspShellState, apply_tide_workspace_republish_item, collect_tide_workspace_republish_streaming,
     complete_tide_workspace_republish, enable_deferred_external_sif_refresh,
@@ -11,7 +13,7 @@ use crate::{
 };
 use serde_json::json;
 
-fn open_style_document(state: &mut LspShellState, uri: &str, text: &str) {
+fn open_document(state: &mut LspShellState, uri: &str, language_id: &str, text: &str) {
     handle_lsp_message(
         state,
         json!({
@@ -20,7 +22,7 @@ fn open_style_document(state: &mut LspShellState, uri: &str, text: &str) {
             "params": {
                 "textDocument": {
                     "uri": uri,
-                    "languageId": "scss",
+                    "languageId": language_id,
                     "version": 1,
                     "text": text,
                 },
@@ -32,17 +34,27 @@ fn open_style_document(state: &mut LspShellState, uri: &str, text: &str) {
 fn republish_fixture_state() -> LspShellState {
     let mut state = LspShellState::default();
     enable_deferred_external_sif_refresh(&mut state);
-    open_style_document(
+    open_document(
         &mut state,
         "file:///workspace/src/Alpha.module.scss",
+        "scss",
         ".alpha { color: red; }",
     );
-    open_style_document(
+    open_document(
         &mut state,
         "file:///workspace/src/Beta.module.scss",
+        "scss",
         ".beta { color: blue; }",
     );
     state
+}
+
+fn settle_sif_lane(state: &mut LspShellState) -> Result<(), &'static str> {
+    let sif_job = crate::prepare_deferred_external_sif_refresh_job(state)
+        .ok_or("startup SIF demand must flush")?;
+    let sif_result = crate::collect_deferred_external_sif_refresh(sif_job);
+    crate::apply_deferred_external_sif_refresh_result(state, sif_result);
+    Ok(())
 }
 
 #[test]
@@ -51,7 +63,7 @@ fn republish_tide_round_trip_covers_the_corpus() -> Result<(), &'static str> {
     let tick = 0;
     state
         .tide_republish_lane
-        .deposit(TideDemandV0::WorkspaceRepublish, tick);
+        .deposit(TideRepublishDemandV0::All, tick);
 
     // The SIF lane holds startup demand (enable_deferred deposits), which
     // closes the republish frontier: no flush yet.
@@ -60,12 +72,7 @@ fn republish_tide_round_trip_covers_the_corpus() -> Result<(), &'static str> {
         "republish must wait for the SIF lane to settle"
     );
 
-    // Settle the SIF lane the way the loop does: flush its demand into a job
-    // and apply the (unchanged) result.
-    let sif_job = crate::prepare_deferred_external_sif_refresh_job(&mut state)
-        .ok_or("startup SIF demand must flush")?;
-    let sif_result = crate::collect_deferred_external_sif_refresh(sif_job);
-    crate::apply_deferred_external_sif_refresh_result(&mut state, sif_result);
+    settle_sif_lane(&mut state)?;
 
     let job = prepare_tide_workspace_republish_job(&mut state, true)
         .ok_or("settled frontier + idle courtesy must flush")?;
@@ -122,25 +129,98 @@ fn republish_tide_round_trip_covers_the_corpus() -> Result<(), &'static str> {
 }
 
 #[test]
+fn cone_flush_targets_only_the_seed_closure() -> Result<(), &'static str> {
+    let mut state = LspShellState::default();
+    enable_deferred_external_sif_refresh(&mut state);
+    handle_lsp_message(
+        &mut state,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "workspaceFolders": [
+                    {"uri": "file:///workspace", "name": "workspace"},
+                ],
+            },
+        }),
+    );
+    // Importer.module.scss uses Tokens.module.scss; Bystander is unrelated.
+    open_document(
+        &mut state,
+        "file:///workspace/src/Tokens.module.scss",
+        "scss",
+        "$brand: red;\n.token { color: $brand; }",
+    );
+    open_document(
+        &mut state,
+        "file:///workspace/src/Importer.module.scss",
+        "scss",
+        "@use \"./Tokens.module.scss\" as tokens;\n.importer { color: red; }",
+    );
+    open_document(
+        &mut state,
+        "file:///workspace/src/Bystander.module.scss",
+        "scss",
+        ".bystander { color: green; }",
+    );
+    open_document(
+        &mut state,
+        "file:///workspace/src/App.tsx",
+        "typescriptreact",
+        "import styles from './Importer.module.scss';\nexport const a = styles.importer;",
+    );
+    settle_sif_lane(&mut state)?;
+    // Drain the startup republish (the SIF apply deposits it).
+    if let Some(job) = prepare_tide_workspace_republish_job(&mut state, true) {
+        let generation = job.generation;
+        collect_tide_workspace_republish_streaming(job, &|_| true);
+        let _ = complete_tide_workspace_republish(&mut state, generation, Vec::new());
+    }
+
+    state.tide_republish_lane.deposit(
+        TideRepublishDemandV0::cone([String::from("file:///workspace/src/Tokens.module.scss")]),
+        1,
+    );
+    let job = prepare_tide_workspace_republish_job(&mut state, true).ok_or("cone must flush")?;
+    let uris = job.target_uris_for_test();
+    assert!(
+        uris.iter().any(|uri| uri.ends_with("Tokens.module.scss")),
+        "the seed itself is a target: {uris:?}"
+    );
+    assert!(
+        !uris
+            .iter()
+            .any(|uri| uri.ends_with("Bystander.module.scss")),
+        "a file outside the seed's reverse closure must NOT be a target: {uris:?}"
+    );
+    let generation = job.generation;
+    collect_tide_workspace_republish_streaming(job, &|_| true);
+    let _ = complete_tide_workspace_republish(&mut state, generation, Vec::new());
+    Ok(())
+}
+
+#[test]
 fn disowned_republish_tide_drops_leftovers_and_rearms() -> Result<(), &'static str> {
     let mut state = republish_fixture_state();
-    let sif_job = crate::prepare_deferred_external_sif_refresh_job(&mut state)
-        .ok_or("startup SIF demand must flush")?;
-    let sif_result = crate::collect_deferred_external_sif_refresh(sif_job);
-    crate::apply_deferred_external_sif_refresh_result(&mut state, sif_result);
+    settle_sif_lane(&mut state)?;
 
     state
         .tide_republish_lane
-        .deposit(TideDemandV0::WorkspaceRepublish, 0);
+        .deposit(TideRepublishDemandV0::All, 0);
     let job = prepare_tide_workspace_republish_job(&mut state, true).ok_or("gate must open")?;
     let generation = job.generation;
 
     // The settle window reopens while the tide is in flight: the generation
     // watch moves, the wave aborts at item boundaries, and completion with
-    // the stale generation must drop leftovers without touching the lane's
-    // NEW generation.
+    // the stale generation must drop leftovers — the disowned demand is
+    // owed again in the NEW window (per-epoch carry-over).
     state.tide_reopen_republish_window();
     assert!(state.tide_republish_lane_generation() > generation);
+    assert!(
+        state.tide_republish_lane.has_demand(),
+        "the disowned tide's coverage carries over into the reopened window"
+    );
 
     let chunks = std::sync::Mutex::new(Vec::new());
     collect_tide_workspace_republish_streaming(job, &|result| {
@@ -169,4 +249,110 @@ fn disowned_republish_tide_drops_leftovers_and_rearms() -> Result<(), &'static s
     );
     assert!(!state.tide_republish_lane.in_flight());
     Ok(())
+}
+
+#[cfg(feature = "salsa-style-diagnostics")]
+mod sif_delta_seeding {
+    use crate::LspShellState;
+    use crate::external_sif_loader::republish_demand_for_external_sif_delta;
+    use crate::state::LspReverseDependencyIndexMemo;
+    use crate::tide::TideRepublishDemandV0;
+    use omena_query::{OmenaQueryExternalSifInputV0, ReverseDependencyIndexV0};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn external_sif(url: &str, content: &[u8]) -> Option<OmenaQueryExternalSifInputV0> {
+        let sif = omena_sif::OmenaSifV1::from_static_exports(
+            url,
+            omena_sif::OmenaSifGeneratorV1 {
+                name: "fixture".to_string(),
+                version: "0.1.0".to_string(),
+                toolchain_id: "fixture@0.1.0".to_string(),
+            },
+            omena_sif::OmenaSifSourceV1 {
+                syntax: omena_sif::OmenaSifSourceSyntaxV1::Scss,
+            },
+            omena_sif::OmenaSifExportsV1 {
+                variables: Vec::new(),
+                mixins: Vec::new(),
+                functions: Vec::new(),
+                placeholders: Vec::new(),
+                forwards: Vec::new(),
+            },
+            Vec::new(),
+            content,
+        )
+        .ok()?;
+        Some(OmenaQueryExternalSifInputV0 {
+            canonical_url: url.to_string(),
+            sif,
+        })
+    }
+
+    fn state_with_reverse_index(edges: &[(&str, &str)]) -> LspShellState {
+        let mut rev: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        for (target, dependent) in edges {
+            rev.entry(target.to_string())
+                .or_default()
+                .insert(dependent.to_string());
+        }
+        let state = LspShellState::default();
+        *state.reverse_dependency_index_memo.borrow_mut() = Some(LspReverseDependencyIndexMemo {
+            revision: 1,
+            summary_hash: "fixture".to_string(),
+            index: ReverseDependencyIndexV0 {
+                rev,
+                edges_by_from: BTreeMap::new(),
+            },
+        });
+        state
+    }
+
+    #[test]
+    fn changed_sif_with_attributed_importers_seeds_a_cone() -> Result<(), &'static str> {
+        let url = "https://cdn.example/tokens.scss";
+        let importer = "file:///workspace/src/User.module.scss";
+        let mut state = state_with_reverse_index(&[(url, importer)]);
+        state.resolution.external_sifs = vec![external_sif(url, b"$brand: red;").ok_or("old sif")?];
+        let next = vec![external_sif(url, b"$brand: blue;").ok_or("new sif")?];
+        assert_eq!(
+            republish_demand_for_external_sif_delta(&state, next.as_slice()),
+            TideRepublishDemandV0::cone([importer.to_string()]),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unattributed_url_and_missing_index_widen_to_all() -> Result<(), &'static str> {
+        let url = "https://cdn.example/tokens.scss";
+        let mut state = state_with_reverse_index(&[("https://other.example/x.scss", "file:///a")]);
+        state.resolution.external_sifs = Vec::new();
+        let next = vec![external_sif(url, b"$brand: red;").ok_or("sif")?];
+        assert_eq!(
+            republish_demand_for_external_sif_delta(&state, next.as_slice()),
+            TideRepublishDemandV0::All,
+            "an unattributable changed url must widen"
+        );
+
+        let mut cold = LspShellState::default();
+        cold.resolution.external_sifs = Vec::new();
+        assert_eq!(
+            republish_demand_for_external_sif_delta(&cold, next.as_slice()),
+            TideRepublishDemandV0::All,
+            "no reverse index (cold start) must widen"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unchanged_sif_set_deposits_nothing() -> Result<(), &'static str> {
+        let url = "https://cdn.example/tokens.scss";
+        let mut state = state_with_reverse_index(&[(url, "file:///a")]);
+        let sif = external_sif(url, b"$brand: red;").ok_or("sif")?;
+        state.resolution.external_sifs = vec![sif.clone()];
+        assert_eq!(
+            republish_demand_for_external_sif_delta(&state, std::slice::from_ref(&sif)),
+            TideRepublishDemandV0::None,
+        );
+        Ok(())
+    }
 }

--- a/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
+++ b/rust/crates/omena-lsp-server/src/tests/tide_republish_executor.rs
@@ -299,6 +299,7 @@ mod sif_delta_seeding {
         *state.reverse_dependency_index_memo.borrow_mut() = Some(LspReverseDependencyIndexMemo {
             revision: 1,
             summary_hash: "fixture".to_string(),
+            ledger_epoch: 0,
             index: ReverseDependencyIndexV0 {
                 rev,
                 edges_by_from: BTreeMap::new(),
@@ -339,6 +340,27 @@ mod sif_delta_seeding {
             republish_demand_for_external_sif_delta(&cold, next.as_slice()),
             TideRepublishDemandV0::All,
             "no reverse index (cold start) must widen"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stale_reverse_index_widens_to_all() -> Result<(), &'static str> {
+        let url = "https://cdn.example/tokens.scss";
+        let importer = "file:///workspace/src/User.module.scss";
+        let mut state = state_with_reverse_index(&[(url, importer)]);
+        state.resolution.external_sifs = vec![external_sif(url, b"$brand: red;").ok_or("old sif")?];
+        // A corpus-shaping input advances past the memo's stamp: the rev-set
+        // for the url is PRESENT but may be missing a just-added importer,
+        // so presence alone must not narrow the demand.
+        state
+            .tide_ledger
+            .advance(&[crate::tide::TideInputKindV0::DocumentText]);
+        let next = vec![external_sif(url, b"$brand: blue;").ok_or("new sif")?];
+        assert_eq!(
+            republish_demand_for_external_sif_delta(&state, next.as_slice()),
+            TideRepublishDemandV0::All,
+            "a stale reverse index must widen, never guess"
         );
         Ok(())
     }

--- a/rust/crates/omena-lsp-server/src/tests/workspace_indexing.rs
+++ b/rust/crates/omena-lsp-server/src/tests/workspace_indexing.rs
@@ -1080,8 +1080,6 @@ fn background_source_index_uses_persisted_source_syntax_sidecar() -> TestResult 
             Some(workspace_uri.as_str()),
             source_uri.as_str(),
             "typescriptreact",
-            text_hash.as_str(),
-            &resolution_inputs,
         )
         .ok_or_else(|| std::io::Error::other("source document sidecar path should resolve"))?;
     assert!(
@@ -1285,13 +1283,10 @@ fn indexed_source_files_feed_references_and_rename() -> TestResult {
         state.workspace_occurrence_index_memo.borrow().is_some(),
         "references should populate the workspace occurrence memo"
     );
-    let document_keys =
-        source_selector_occurrence_document_keys(&state, Some(workspace_uri.as_str()));
     let sidecar_path =
         crate::source_occurrence_cache::source_occurrence_sidecar_file_path_for_test(
             &state,
             Some(workspace_uri.as_str()),
-            document_keys.as_slice(),
         )
         .ok_or_else(|| std::io::Error::other("source occurrence sidecar path should resolve"))?;
     assert!(
@@ -3339,12 +3334,10 @@ fn indexed_style_files_feed_custom_property_references_and_rename() -> TestResul
         state.workspace_occurrence_index_memo.borrow().is_some(),
         "custom property definition should populate the workspace occurrence memo"
     );
-    let document_keys = style_symbol_occurrence_document_keys(&state, Some(workspace_uri.as_str()));
     let sidecar_path =
         crate::style_symbol_occurrence_cache::style_symbol_occurrence_sidecar_file_path_for_test(
             &state,
             Some(workspace_uri.as_str()),
-            document_keys.as_slice(),
         )
         .ok_or_else(|| {
             std::io::Error::other("style symbol occurrence sidecar path should resolve")
@@ -3526,12 +3519,10 @@ fn indexed_style_files_feed_sass_symbol_references_and_rename() -> TestResult {
         state.workspace_occurrence_index_memo.borrow().is_some(),
         "Sass references should populate the workspace occurrence memo"
     );
-    let document_keys = style_symbol_occurrence_document_keys(&state, Some(workspace_uri.as_str()));
     let sidecar_path =
         crate::style_symbol_occurrence_cache::style_symbol_occurrence_sidecar_file_path_for_test(
             &state,
             Some(workspace_uri.as_str()),
-            document_keys.as_slice(),
         )
         .ok_or_else(|| {
             std::io::Error::other("style symbol occurrence sidecar path should resolve")

--- a/rust/crates/omena-lsp-server/src/tide/demand.rs
+++ b/rust/crates/omena-lsp-server/src/tide/demand.rs
@@ -1,24 +1,111 @@
-//! Demand lanes and settle gates (rfcs#111 §4.1, §9.6).
+//! Demand lanes and settle gates (rfcs#111 §4.1, §9.6), lattice edition.
 //!
-//! Trigger sites deposit demands — idempotently, into a set — and nothing
-//! else; whether, when, and how often work executes is decided here, once,
-//! at gate evaluation. The gate has two layers with strictly different
-//! authority (rfcs#111 §7 I5):
+//! A lane is an LVar cell (Kuper & Newton, FHPC 2013): its content is one
+//! join-semilattice value, trigger sites DEPOSIT by least-upper-bound —
+//! monotone, idempotent, commutative — and nothing else; whether, when, and
+//! how often work executes is decided here, once, at gate evaluation. The
+//! gate is a threshold read with two layers of strictly different authority
+//! (rfcs#111 §7 I5):
 //!
 //! - the CORRECTNESS layer — frontier passage — is never overridable;
 //! - the COURTESY layer — idleness — may be overridden by aging.
 //!
 //! If upstream genuinely never settles, not flushing is correct, and the
 //! lane records a starvation alarm instead of forcing a flush.
+//!
+//! PER-EPOCH SCOPING ("Freeze After Writing", Kuper et al., POPL 2014): a
+//! settle-window reopen is a retraction, which a pure LVar forbids. The
+//! lattice is therefore scoped to one window: demands accumulate
+//! monotonically within it, a flush freezes the accumulated value into an
+//! in-flight tide, and a reopen JOINS that frozen value back into the new
+//! window. Coverage owed can grow or carry over, never silently shrink —
+//! previously the "a disowned tide's keys are re-covered" invariant leaned
+//! on every deposit being the whole workspace; with cone-shaped demands the
+//! carry-over makes it structural.
 
 use std::collections::BTreeSet;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TideDemandV0 {
-    /// Full-workspace external SIF re-resolution.
-    SifRefresh,
-    /// Full-workspace diagnostics republish (the post-SIF follow-up).
-    WorkspaceRepublish,
+/// One lane's demand vocabulary: a join-semilattice with a bottom element.
+/// `join` must be idempotent, commutative, and associative; `deposit` and
+/// the window carry-over both go through it.
+pub trait TideDemandJoinV0: Clone + PartialEq {
+    fn bottom() -> Self;
+    fn is_bottom(&self) -> bool;
+    fn join(&mut self, other: Self);
+}
+
+/// The SIF lane's demand: the two-point lattice — either a full external
+/// SIF re-resolution is owed or nothing is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TideSifDemandV0 {
+    owed: bool,
+}
+
+impl TideSifDemandV0 {
+    pub fn refresh() -> Self {
+        Self { owed: true }
+    }
+}
+
+impl TideDemandJoinV0 for TideSifDemandV0 {
+    fn bottom() -> Self {
+        Self { owed: false }
+    }
+
+    fn is_bottom(&self) -> bool {
+        !self.owed
+    }
+
+    fn join(&mut self, other: Self) {
+        self.owed |= other.owed;
+    }
+}
+
+/// The republish lane's demand: the powerset lattice of seed paths with an
+/// absorbing top. `Cone` carries SEEDS — the reverse-dependency closure is
+/// taken at FLUSH time against the then-current committed graph, so a seed
+/// deposited early still fans out over edges that appear before the flush.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TideRepublishDemandV0 {
+    /// ⊥ — nothing owed.
+    None,
+    /// Republish the reverse-dependency cones of these seed paths.
+    Cone(BTreeSet<String>),
+    /// ⊤ — the whole workspace.
+    All,
+}
+
+impl TideRepublishDemandV0 {
+    pub fn cone(seeds: impl IntoIterator<Item = String>) -> Self {
+        let seeds: BTreeSet<String> = seeds.into_iter().collect();
+        if seeds.is_empty() {
+            Self::None
+        } else {
+            Self::Cone(seeds)
+        }
+    }
+}
+
+impl TideDemandJoinV0 for TideRepublishDemandV0 {
+    fn bottom() -> Self {
+        Self::None
+    }
+
+    fn is_bottom(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    fn join(&mut self, other: Self) {
+        *self = match (std::mem::replace(self, Self::None), other) {
+            (Self::All, _) | (_, Self::All) => Self::All,
+            (Self::None, other) => other,
+            (current, Self::None) => current,
+            (Self::Cone(mut seeds), Self::Cone(more)) => {
+                seeds.extend(more);
+                Self::Cone(seeds)
+            }
+        };
+    }
 }
 
 /// Per-evaluation gate inputs, fed by the shell. The kernel never reads
@@ -38,35 +125,66 @@ pub struct TideLaneConfigV0 {
     pub aging_bound_ticks: u64,
 }
 
-/// One gated flush: the demands drained from the lane, stamped with the
-/// lane generation that executors re-check at item boundaries.
+/// One gated flush: the lattice value frozen out of the lane, stamped with
+/// the lane generation that executors re-check at item boundaries.
 #[derive(Debug, PartialEq, Eq)]
-pub struct TideFlushV0 {
+pub struct TideFlushV0<D> {
     pub generation: u64,
-    pub demands: Vec<TideDemandV0>,
+    pub demand: D,
 }
 
-#[derive(Debug, Default)]
-pub struct TideLaneV0 {
-    demands: BTreeSet<TideDemandV0>,
+/// The frozen state of an in-flight tide: its lattice value plus the age of
+/// its oldest deposit, both restored on a window reopen so carried-over
+/// demand neither loses coverage nor gets a fresh (or ancient) age.
+#[derive(Debug)]
+struct TideInFlightV0<D> {
+    demand: D,
+    oldest_deposit_tick: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct TideLaneV0<D: TideDemandJoinV0> {
+    demand: D,
+    /// The frozen in-flight tide. A window reopen joins it back into
+    /// `demand` (per-epoch carry-over); a current-generation completion
+    /// discharges it.
+    in_flight: Option<TideInFlightV0<D>>,
     generation: u64,
-    in_flight: bool,
     oldest_deposit_tick: Option<u64>,
     starvation_alarmed: bool,
     starvation_alarm_count: u64,
 }
 
-impl TideLaneV0 {
-    /// Idempotent deposit; returns whether the demand was newly inserted.
-    pub fn deposit(&mut self, demand: TideDemandV0, now_tick: u64) -> bool {
+impl<D: TideDemandJoinV0> Default for TideLaneV0<D> {
+    fn default() -> Self {
+        Self {
+            demand: D::bottom(),
+            in_flight: None,
+            generation: 0,
+            oldest_deposit_tick: None,
+            starvation_alarmed: false,
+            starvation_alarm_count: 0,
+        }
+    }
+}
+
+impl<D: TideDemandJoinV0> TideLaneV0<D> {
+    /// Monotone deposit: joins into the lane's lattice value. Returns
+    /// whether the value actually grew.
+    pub fn deposit(&mut self, demand: D, now_tick: u64) -> bool {
+        if demand.is_bottom() {
+            return false;
+        }
         if self.oldest_deposit_tick.is_none() {
             self.oldest_deposit_tick = Some(now_tick);
         }
-        self.demands.insert(demand)
+        let before = self.demand.clone();
+        self.demand.join(demand);
+        self.demand != before
     }
 
     pub fn has_demand(&self) -> bool {
-        !self.demands.is_empty()
+        !self.demand.is_bottom()
     }
 
     pub fn generation(&self) -> u64 {
@@ -74,25 +192,26 @@ impl TideLaneV0 {
     }
 
     pub fn in_flight(&self) -> bool {
-        self.in_flight
+        self.in_flight.is_some()
     }
 
     pub fn starvation_alarm_count(&self) -> u64 {
         self.starvation_alarm_count
     }
 
-    /// Gate evaluation. Flushes at most one tide per settle window: while a
-    /// tide is in flight or the lane is empty, this is a no-op regardless of
-    /// gate inputs (I1). Aging can satisfy the courtesy layer, never the
-    /// correctness layer; an aged demand behind a closed frontier raises the
-    /// starvation alarm once per accumulation window (I5).
+    /// Gate evaluation — the threshold read. Flushes at most one tide per
+    /// settle window: while a tide is in flight or the lane is at bottom,
+    /// this is a no-op regardless of gate inputs (I1). Aging can satisfy
+    /// the courtesy layer, never the correctness layer; an aged demand
+    /// behind a closed frontier raises the starvation alarm once per
+    /// accumulation window (I5).
     pub fn try_flush(
         &mut self,
         inputs: TideGateInputsV0,
         now_tick: u64,
         config: &TideLaneConfigV0,
-    ) -> Option<TideFlushV0> {
-        if self.in_flight || self.demands.is_empty() {
+    ) -> Option<TideFlushV0<D>> {
+        if self.in_flight.is_some() || self.demand.is_bottom() {
             return None;
         }
         let aged = self
@@ -109,33 +228,43 @@ impl TideLaneV0 {
             return None;
         }
         self.generation = self.generation.saturating_add(1);
-        self.in_flight = true;
-        self.oldest_deposit_tick = None;
         self.starvation_alarmed = false;
+        let demand = std::mem::replace(&mut self.demand, D::bottom());
+        self.in_flight = Some(TideInFlightV0 {
+            demand: demand.clone(),
+            oldest_deposit_tick: self.oldest_deposit_tick.take(),
+        });
         Some(TideFlushV0 {
             generation: self.generation,
-            demands: std::mem::take(&mut self.demands).into_iter().collect(),
+            demand,
         })
     }
 
     /// Upstream input relevant to this lane changed while a tide was in
-    /// flight: the settle window reopens. The running tide is disowned — its
-    /// generation no longer matches, so the executor aborts at the next item
-    /// boundary and its remaining publishes lose supersession (rfcs#111
-    /// §9.4). Returns the new generation for executors' gen-watch.
+    /// flight: the settle window reopens. The running tide is disowned —
+    /// its generation no longer matches, so the executor aborts at the next
+    /// item boundary — and its frozen demand is JOINED back into the new
+    /// window, so the coverage it owed is owed again (per-epoch carry-over;
+    /// rfcs#111 §9.4). Returns the new generation for executors' gen-watch.
     pub fn reopen_window(&mut self) -> u64 {
-        if self.in_flight {
+        if let Some(disowned) = self.in_flight.take() {
             self.generation = self.generation.saturating_add(1);
-            self.in_flight = false;
+            self.demand.join(disowned.demand);
+            self.oldest_deposit_tick =
+                match (self.oldest_deposit_tick, disowned.oldest_deposit_tick) {
+                    (Some(current), Some(carried)) => Some(current.min(carried)),
+                    (tick, None) | (None, tick) => tick,
+                };
         }
         self.generation
     }
 
-    /// Executor completion for `generation`. Stale completions — a tide that
-    /// was disowned by `reopen_window` — are ignored.
+    /// Executor completion for `generation`: discharges the frozen demand.
+    /// Stale completions — a tide that was disowned by `reopen_window` —
+    /// are ignored; their obligation already carried over.
     pub fn tide_completed(&mut self, generation: u64) {
         if generation == self.generation {
-            self.in_flight = false;
+            self.in_flight = None;
         }
     }
 }

--- a/rust/crates/omena-lsp-server/src/tide/ledger.rs
+++ b/rust/crates/omena-lsp-server/src/tide/ledger.rs
@@ -29,6 +29,10 @@ pub enum TideInputKindV0 {
 
 pub const TIDE_INPUT_KIND_COUNT: usize = 7;
 
+// The footprint bitset is a u8: adding a ninth input kind must widen it,
+// not silently shift out of range.
+const _: () = assert!(TIDE_INPUT_KIND_COUNT <= 8);
+
 impl TideInputKindV0 {
     pub const ALL: [TideInputKindV0; TIDE_INPUT_KIND_COUNT] = [
         TideInputKindV0::DocumentText,

--- a/rust/crates/omena-lsp-server/src/tide/mod.rs
+++ b/rust/crates/omena-lsp-server/src/tide/mod.rs
@@ -10,7 +10,10 @@
 pub mod demand;
 pub mod ledger;
 
-pub use demand::{TideDemandV0, TideFlushV0, TideGateInputsV0, TideLaneConfigV0, TideLaneV0};
+pub use demand::{
+    TideDemandJoinV0, TideFlushV0, TideGateInputsV0, TideLaneConfigV0, TideLaneV0,
+    TideRepublishDemandV0, TideSifDemandV0,
+};
 pub use ledger::{TideEpochLedgerV0, TideFootprintStampV0, TideFootprintV0, TideInputKindV0};
 
 /// Publication supersession rule (rfcs#111 §8.4): per-key last-writer-wins on

--- a/rust/crates/omena-lsp-server/src/tide_republish.rs
+++ b/rust/crates/omena-lsp-server/src/tide_republish.rs
@@ -11,15 +11,14 @@
 //! republished by the reopened window's tide, and the publication order key
 //! forbids any stale overwrite.
 
+use crate::LspShellState;
 use crate::diagnostics_follow_up::{
     TIDE_REPUBLISH_LANE_CONFIG, workspace_republish_frontier_passed,
 };
 use crate::disk_cache::DiskDiagnosticsCacheSlotV0;
 use crate::lsp_output::ScheduledLspOutput;
-use crate::protocol::is_style_document_uri;
 use crate::state::LspQuerySnapshotV0;
 use crate::tide::TideGateInputsV0;
-use crate::{LspDocumentOrigin, LspShellState};
 use serde_json::Value;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -30,6 +29,13 @@ pub struct TideWorkspaceRepublishJobV0 {
     uris: Vec<String>,
     pub generation: u64,
     gen_watch: Arc<AtomicU64>,
+}
+
+impl TideWorkspaceRepublishJobV0 {
+    #[cfg(test)]
+    pub(crate) fn target_uris_for_test(&self) -> &[String] {
+        self.uris.as_slice()
+    }
 }
 
 #[derive(Debug)]
@@ -74,32 +80,24 @@ pub fn prepare_tide_workspace_republish_job(
     state
         .tide_republish_gen_watch
         .store(flush.generation, Ordering::Relaxed);
-    // Open documents first — the user is looking at them — then the rest;
-    // canonical order within each group. Chunked streaming below turns this
-    // ordering into convergence latency for the open files.
-    let mut uris: Vec<String> = Vec::new();
-    let mut unopened: Vec<String> = Vec::new();
-    for document in state.documents.values() {
-        if document.origin != LspDocumentOrigin::Local
-            || !is_style_document_uri(document.uri.as_str())
-        {
-            continue;
-        }
-        if state.has_open_document_uri(document.uri.as_str()) {
-            uris.push(document.uri.clone());
-        } else {
-            unopened.push(document.uri.clone());
-        }
-    }
-    uris.extend(unopened);
+    // Demand-shaped targeting (rfcs#111 demand lattice): `All` covers the
+    // corpus, `Cone` covers the seeds' reverse-dependency closure at flush
+    // time. Open documents come first — the user is looking at them — and
+    // chunked streaming below turns that ordering into convergence latency.
+    let uris = crate::diagnostics_follow_up::tide_republish_target_uris(state, &flush.demand);
     if uris.is_empty() {
         state.tide_republish_lane.tide_completed(flush.generation);
         return None;
     }
     crate::loop_trace!(
-        "republish-tide prepared gen={} targets={}",
+        "republish-tide prepared gen={} targets={} demand={}",
         flush.generation,
-        uris.len()
+        uris.len(),
+        match &flush.demand {
+            crate::tide::TideRepublishDemandV0::All => "all".to_string(),
+            crate::tide::TideRepublishDemandV0::Cone(seeds) => format!("cone({})", seeds.len()),
+            crate::tide::TideRepublishDemandV0::None => "none".to_string(),
+        }
     );
     Some(TideWorkspaceRepublishJobV0 {
         snapshot: state.query_snapshot(),

--- a/rust/crates/omena-lsp-server/src/workspace_index.rs
+++ b/rust/crates/omena-lsp-server/src/workspace_index.rs
@@ -183,7 +183,7 @@ pub fn apply_background_workspace_index_result(
         let tick = state.tide_tick;
         state
             .tide_sif_lane
-            .deposit(crate::tide::TideDemandV0::SifRefresh, tick);
+            .deposit(crate::tide::TideSifDemandV0::refresh(), tick);
     }
     crate::refresh_external_sifs_for_bridge_source_delta(
         state,

--- a/rust/crates/omena-lsp-server/src/workspace_occurrence_cache.rs
+++ b/rust/crates/omena-lsp-server/src/workspace_occurrence_cache.rs
@@ -9,7 +9,7 @@ const WORKSPACE_OCCURRENCE_SHARD_SCHEMA_VERSION: &str = "0";
 const WORKSPACE_OCCURRENCE_SHARD_PRODUCT: &str = "omena-lsp-server.workspace-occurrence-shard";
 const WORKSPACE_OCCURRENCE_SHARD_KEY_PRODUCT: &str =
     "omena-lsp-server.workspace-occurrence-shard-key";
-const WORKSPACE_OCCURRENCE_SHARD_DIR: &str = "workspace-occurrence-shards-v0";
+const WORKSPACE_OCCURRENCE_SHARD_DIR: &str = "workspace-occurrence-shards-v1";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,7 +46,7 @@ pub(crate) fn load_workspace_occurrence_shard(
         dependency_digest,
         resolution_inputs,
     )?;
-    let path = workspace_occurrence_shard_path(workspace_folder_uri, key.as_str())?;
+    let path = workspace_occurrence_shard_path(workspace_folder_uri, document_uri, language_id)?;
     let bytes = fs::read(path).ok()?;
     let shard: Value = serde_json::from_slice(bytes.as_slice()).ok()?;
     if shard.pointer("/schemaVersion").and_then(Value::as_str)
@@ -107,7 +107,9 @@ pub(crate) fn store_workspace_occurrence_shard(
     ) else {
         return;
     };
-    let Some(path) = workspace_occurrence_shard_path(workspace_folder_uri, key.as_str()) else {
+    let Some(path) =
+        workspace_occurrence_shard_path(workspace_folder_uri, document_uri, language_id)
+    else {
         return;
     };
     let Some(dir) = path.parent() else {
@@ -188,11 +190,18 @@ fn workspace_occurrence_shard_key(
 
 fn workspace_occurrence_shard_path(
     workspace_folder_uri: Option<&str>,
-    key: &str,
+    document_uri: &str,
+    language_id: &str,
 ) -> Option<PathBuf> {
     let workspace_folder_uri = workspace_folder_uri?;
     let root = file_uri_to_path(workspace_folder_uri)?;
-    let hex = key.strip_prefix("blake3:")?;
+    // Stable address (identity, never content): one file per document,
+    // overwritten in place; the content key is a load-verified shard field.
+    let address = crate::disk_cache::stable_cache_shard_address(
+        WORKSPACE_OCCURRENCE_SHARD_PRODUCT,
+        &[workspace_folder_uri, document_uri, language_id],
+    )?;
+    let hex = address.strip_prefix("blake3:")?.to_string();
     if hex.is_empty() || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
         return None;
     }
@@ -260,9 +269,13 @@ mod tests {
             &resolution_inputs,
         )
         .ok_or("missing workspace occurrence shard key")?;
-        let shard_path =
-            workspace_occurrence_shard_path(Some(workspace_uri.as_str()), key.as_str())
-                .ok_or("missing workspace occurrence shard path")?;
+        let _ = key;
+        let shard_path = workspace_occurrence_shard_path(
+            Some(workspace_uri.as_str()),
+            document_uri.as_str(),
+            "typescriptreact",
+        )
+        .ok_or("missing workspace occurrence shard path")?;
         let first_bytes = fs::read(shard_path.as_path())?;
         let first_json: Value = serde_json::from_slice(first_bytes.as_slice())?;
 

--- a/rust/crates/omena-query/src/lib.rs
+++ b/rust/crates/omena-query/src/lib.rs
@@ -65,7 +65,8 @@ pub use omena_cross_file_summary::{
     collect_directed_graph_cycles_with_work_cap, collect_directed_graph_sccs,
     collect_hypergraph_transitive_closure_paths,
     collect_hypergraph_transitive_closure_paths_with_mode, collect_reachable_node_ids,
-    collect_reachable_node_ids_bitset, reverse_dependency_closure_v0,
+    collect_reachable_node_ids_bitset, diagnostics_read_set_for_target_v0,
+    reverse_dependency_closure_v0,
     reverse_dependency_index_from_edges_v0, summarize_omena_query_unified_cross_file_hypergraph,
     summarize_omena_query_unified_cross_file_scc_report, tabulate_hypergraph_ifds_summary_edges,
 };

--- a/rust/crates/omena-query/src/lib.rs
+++ b/rust/crates/omena-query/src/lib.rs
@@ -66,8 +66,8 @@ pub use omena_cross_file_summary::{
     collect_hypergraph_transitive_closure_paths,
     collect_hypergraph_transitive_closure_paths_with_mode, collect_reachable_node_ids,
     collect_reachable_node_ids_bitset, diagnostics_read_set_for_target_v0,
-    reverse_dependency_closure_v0,
-    reverse_dependency_index_from_edges_v0, summarize_omena_query_unified_cross_file_hypergraph,
+    reverse_dependency_closure_v0, reverse_dependency_index_from_edges_v0,
+    summarize_omena_query_unified_cross_file_hypergraph,
     summarize_omena_query_unified_cross_file_scc_report, tabulate_hypergraph_ifds_summary_edges,
 };
 pub use omena_parser::{

--- a/rust/crates/omena-query/tests/snapshots/public-api.txt
+++ b/rust/crates/omena-query/tests/snapshots/public-api.txt
@@ -179,6 +179,7 @@ pub use omena_query::compose_omena_query_transform_source_map_v3_with_upstream_m
 pub use omena_query::conservative_omena_query_target_options
 pub use omena_query::default_omena_query_transform_print_options
 pub use omena_query::derive_cascade_restriction_maps_v0
+pub use omena_query::diagnostics_read_set_for_target_v0
 pub use omena_query::generate_omena_bridge_sif_for_resolved_style_path
 pub use omena_query::generate_omena_bridge_sif_for_resolved_style_path_with_cache_context
 pub use omena_query::invalidate_omena_resolver_style_identity_cache

--- a/rust/omena-two-tier-identity-inventory.json
+++ b/rust/omena-two-tier-identity-inventory.json
@@ -50,7 +50,7 @@
   {
     "id": "rust/crates/omena-lsp-server/src/state.rs#LspShellState.documents",
     "sourcePath": "rust/crates/omena-lsp-server/src/state.rs",
-    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:357",
+    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:361",
     "owner": "LspShellState",
     "name": "documents",
     "collectionType": "BTreeMap<LspFileId, Arc<LspTextDocumentState>>",
@@ -62,7 +62,7 @@
   {
     "id": "rust/crates/omena-lsp-server/src/state.rs#LspShellState.open_document_uris",
     "sourcePath": "rust/crates/omena-lsp-server/src/state.rs",
-    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:358",
+    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:362",
     "owner": "LspShellState",
     "name": "open_document_uris",
     "collectionType": "BTreeSet<LspFileId>",
@@ -74,7 +74,7 @@
   {
     "id": "rust/crates/omena-lsp-server/src/state.rs#LspShellState.pending_server_progress_request_tokens",
     "sourcePath": "rust/crates/omena-lsp-server/src/state.rs",
-    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:364",
+    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:368",
     "owner": "LspShellState",
     "name": "pending_server_progress_request_tokens",
     "collectionType": "BTreeMap<String, String>",
@@ -86,7 +86,7 @@
   {
     "id": "rust/crates/omena-lsp-server/src/state.rs#LspShellState.source_type_fact_cache",
     "sourcePath": "rust/crates/omena-lsp-server/src/state.rs",
-    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:377",
+    "sourceAnchor": "rust/crates/omena-lsp-server/src/state.rs:381",
     "owner": "LspShellState",
     "name": "source_type_fact_cache",
     "collectionType": "BTreeMap<String, Vec<TsgoTypeFactResultEntryV0>>",

--- a/scripts/check-rust-omena-lsp-server-boundary.ts
+++ b/scripts/check-rust-omena-lsp-server-boundary.ts
@@ -159,7 +159,7 @@ for (const requiredTrustPolicy of [
 // RFC 0009 Pillar C (rfcs#66): the disk diagnostics cache is the ONLY declared
 // local-disk write surface; the neverFetch network invariant stays untouched.
 assert.deepEqual(rustSummary.trustBoundary.diskWriteSurfaces, [
-  "<workspaceFolder>/.cache/omena/diagnostics-cache-v0",
+  "<workspaceFolder>/.cache/omena/diagnostics-cache-v1",
 ]);
 assert.ok(
   !/^\s*engine-style-parser\s*=/.test(lspServerCargoToml),
@@ -420,17 +420,19 @@ assert.ok(
 );
 assert.equal(rustSummary.diskDiagnosticsCache.product, "omena-lsp-server.disk-diagnostics-cache");
 assert.equal(rustSummary.diskDiagnosticsCache.owner, "omena-lsp-server/diskDiagnosticsCache");
-assert.equal(rustSummary.diskDiagnosticsCache.cacheModel, "contentAddressedExactMatchShardStore");
+assert.equal(rustSummary.diskDiagnosticsCache.cacheModel, "verifyingTraceStableAddressShardStore");
 assert.equal(
   rustSummary.diskDiagnosticsCache.storageLocation,
-  "<workspaceFolder>/.cache/omena/diagnostics-cache-v0",
+  "<workspaceFolder>/.cache/omena/diagnostics-cache-v1",
 );
 for (const requiredReusePolicy of [
-  "contentAddressedExactKeyMatchOnly",
-  "keyChainsFullDiagnosticsInputSurface",
+  "stableAddressPerTargetOneShardEach",
+  "recordedReadSetVerifiedPerDependencyContentHash",
+  "environmentFingerprintPinsMembershipAndSettings",
+  "manifestMustIncludeTargetItself",
   "schemaValidateShardsBeforeServe",
   "oversizedOrUnparsableShardsAreDeletedMisses",
-  "neverTrustShardContentBeyondExactKeyServe",
+  "readSetCompletenessOracleGatedNotAssumed",
 ]) {
   assert.ok(
     rustSummary.diskDiagnosticsCache.reusePolicy.includes(requiredReusePolicy),

--- a/scripts/check-rust-omena-lsp-server-boundary.ts
+++ b/scripts/check-rust-omena-lsp-server-boundary.ts
@@ -159,7 +159,7 @@ for (const requiredTrustPolicy of [
 // RFC 0009 Pillar C (rfcs#66): the disk diagnostics cache is the ONLY declared
 // local-disk write surface; the neverFetch network invariant stays untouched.
 assert.deepEqual(rustSummary.trustBoundary.diskWriteSurfaces, [
-  "<workspaceFolder>/.cache/omena/diagnostics-cache-v1",
+  "<workspaceFolder>/.cache/omena/**",
 ]);
 assert.ok(
   !/^\s*engine-style-parser\s*=/.test(lspServerCargoToml),


### PR DESCRIPTION
# Tidepool: verifying-trace disk diagnostics cache (stage 2)

Rebased on master after #145 merged. Follow-up commits on this branch add the next slice: the per-epoch lattice demand vocabulary (see the "Stage 3" section below).

## Problem

The stage-1 disk diagnostics cache keyed every shard by a hash of the FULL diagnostics input surface. Two structural consequences, measured on a synthetic 120-module corpus (hub + chains + leaves + failure-path external specifiers, per the #145 lesson that success-only corpora acquit falsely):

1. **Precision:** one changed file invalidated every target's shard. A single-leaf edit before restart pushed the wave from 0.80s (all hits) back to 2.30s — exactly the no-cache cold time. The cache only ever served "nothing changed at all" restarts.
2. **Cost:** key construction canonical-JSON-serialized and hashed the whole corpus PER TARGET — O(N x corpus) bytes per wave. Even the all-hit wave paid 0.80s in key hashing alone.

The same lattice-coarseness appears in three layers (edit-path fan-out is cone-scoped; the demand vocabulary and the cache key were both effectively top). This PR fixes the cache layer.

## Design: verifying traces at stable addresses

Following the rebuilder taxonomy of Mokhov, Mitchell & Peyton Jones, "Build Systems à la Carte" (ICFP 2018): stage 1 was a constructive trace with a monolithic key; stage 2 is a **verifying trace**.

- **Stable address:** shard filename derives from (schema, arm, target path) only — one shard per target, overwritten in place. The stage-1 accumulation of dead content-keyed shards cannot recur, and the legacy `diagnostics-cache-v0` directory is swept best-effort once per session.
- **Recorded read-set:** each shard stores `(path, contentHash)` rows for the read-set its compute declared: the target, its forward closure, and its direct reverse neighbors over the committed cross-file summary edges (new `diagnostics_read_set_for_target_v0`). Lookup re-hashes only the recorded rows against the current surface (hashes memoized once per wave), so a hit survives edits OUTSIDE the target's dependency cone.
- **Environment fingerprint:** ONE hash per wave pins everything membership- or settings-shaped: sorted style/source path sets (a new file can change what a previously-failing specifier resolves to), package manifests, true-external SIFs, resolver configuration, severity, deep-analysis, crate + binary fingerprints.
- **Soundness:** the classic depfile argument — same recorded inputs => same reads => same output — with the membership fingerprint pinning the resolver's candidate space. Completeness of the read-set is **oracle-gated, not assumed**: `OMENA_LSP_DISK_CACHE_ORACLE=1` keeps verified hits in the compute group and byte-compares served vs computed (mismatch counters + trace lines).

## Soak findings: two fingerprint leaks (the interesting bugs)

A verifying trace only works if the environment half is quiet under member edits. Soak on the synthetic corpus caught two derived-fact classes that leaked member volatility into the fingerprint, each re-creating stage-1 global invalidation:

1. `disk_style_path_identities` — length+mtime snapshots of resolver candidates. Saving any corpus member moved its mtime and the fingerprint (leaf-edit restart waved 1.78s instead of 0.13s).
2. Bridge SIFs generated FROM corpus members — chain-import targets embed the member's content bytes, so editing any chain-imported module moved the fingerprint the same way.

Both fact classes are derived from files whose content hashes are already manifest rows (a strictly stronger guard), and every compute that reads such a fact reaches the member through an import edge — so the member is in its recorded read-set. The fingerprint now keeps only facts about the world OUTSIDE the corpora. Fixture tests pin both exclusions and both retention cases (true externals and disk-only candidates stay environmental).

General lesson worth keeping: in a verifying-trace design, audit every input for derived facts of recorded dependencies — each one is a silent fingerprint leak that degrades the store back to top-keying.

## Measurements

Synthetic corpus (120 modules + consumers, M-series laptop, release):

| Restart scenario | stage 1 wave | stage 2 wave |
|---|---|---|
| cold, no cache | 2.35s | 1.65s |
| unchanged | 0.80s | **0.11s** |
| after one LEAF edit | 2.30s | **0.10s** (23x) |
| after mid-module edit | ~2.3s | 1.58s — 2 true misses; the cost is the per-wave substrate, hits stream at 0.1s |
| after HUB edit | 2.36s | 1.68s (honest: dependents truly changed) |

Shadow oracle: **0 mismatches** in every scenario, including post-edit oracle runs.

Real 137-style-document workspace:

- warm-restart republish wave: **137 targets in 0.17s** (14.1s post-#145, 74.3s before it);
- open-document cross-file diagnostics convergence after restart: 20.3s cold → **5.9s** (~2.5s after didOpen);
- shard population: exactly 137 files, one per target.

## Not done, deliberately

- Small-miss-group routing around the per-wave substrate build (the 1.5s fixed cost when only 2 misses exist): hits already stream at 0.1s and only the miss tail is delayed; thin win vs regression surface in the edit-path wave. Re-evaluate after soak.
- The straight-line (non-salsa) arm has no committed summary, hence no sound manifest: it no longer stores shards (it was uncacheable in practice before too — any edit killed the stage-1 key).
- Demand-vocabulary refinement (cone-scoped republish demands as a join semilattice) is the same fix one layer up; separate RFC to follow.

## Tests

- 26 unit tests in `disk_cache.rs` (address stability, fingerprint pinning incl. both leak regressions, outside-edit hits, inside-edit clean misses, membership misses, store preconditions, caps/eviction, tamper/digest/shape rejection, kill switch, legacy sweep, markers).
- Integration tests updated: in-place overwrite semantics, sentinel serve-from-shard, fingerprint sensitivity to resolver disk identity.
- `cargo clippy --all-targets` clean; lsp-server 194+11, query 627+1 green; boundary contract check updated and green.

---

# Stage 3 (same branch): per-epoch lattice demand lanes + cache-growth closure

## Demand lattice (the same fix one layer up)

`TideLaneV0` is now generic over a join-semilattice (`TideDemandJoinV0`): a lane is an LVar cell (Kuper & Newton, FHPC 2013) — deposits are least-upper-bounds, the settle gate is a threshold read, and the LVars determinism theorem covers out-of-order deposits + one-flush-per-window. The SIF lane uses the two-point lattice; the republish lane uses `None < Cone(seeds) < All`.

**Per-epoch scoping** ("Freeze After Writing", POPL 2014): a window reopen is a retraction, which pure LVars forbid — so a flush freezes the lattice value into the in-flight tide and a reopen JOINS it back into the new window, carrying its original deposit age. Coverage owed can grow or carry over, never silently shrink. Previously the disowned-tide re-coverage invariant leaned on every deposit being the whole workspace; with cone-shaped demands the carry-over makes it structural.

**Cone seeding:** a SIF delta deposits `Cone(importers of every changed url)` via the loop's reverse-dependency index; an unattributable url or a missing index (cold start) widens to `All`, never the other direction. The flush resolves seeds to their reverse-dependency closure against the THEN-CURRENT committed graph, filtered to admitted style targets, open documents first.

**Tests:** kernel property harness extended — semilattice laws (idempotent/commutative/associative/identity over random values), deposit-order confluence, disown carry-over conservation, carried-age preservation, plus the existing I1/I5 random-stream invariants against an independent model; executor tests for cone targeting and disowned-demand carry-over; unit tests for the SIF-delta seeding (attributed cone / unattributed widening / cold widening / no-op delta).

## Cache-growth closure (the audit the review asked for)

The growth audit found the stage-1 content-keyed pattern alive in five more subsystems: occurrence, document-index, type-fact, and style-symbol sidecars all derived filenames from content keys — every corpus state wrote a new file, no eviction. Measured on a real 137-document workspace: 83MB + 43MB + 11MB + 8.7MB of dead shards. All five now use the shared `stable_cache_shard_address` (identity-only filenames, content key kept inside as the load-verified field every loader already checked), directories bump to `-v1`, and the legacy sweep generalizes to the full list of retired stores. E2E: sidecar file counts now equal document counts exactly.

Also from the review: the trust boundary declared only the diagnostics store as a disk write surface while six subsystems write under the cache root — now declared honestly as the root glob; and a pre-existing flaky stdio test (fixed 20x75ms polling window against a time-budgeted background scan; 2/5 failures on a loaded machine, on master too) now waits on the observed condition.

## Full-stack measurements (synthetic corpus, release)

| Scenario | wave |
|---|---|
| cold | 1.67s |
| restart unchanged | **0.14s** |
| restart after leaf edit | **0.10s** |
| shadow-oracle mismatches | **0** everywhere |

Cone-shaped tides appear on live SIF deltas (trace: `republish-tide prepared ... demand=cone(n)`); cold paths widen to `all` by design.

## Adversarial review findings (independent reviewer, fixed on this branch)

- **MAJOR — pump completed the tide mid-stream.** The apply pump's completion gate checked only "queue drained", which a streaming wave satisfies on every loop turn between trickling items. Early completion cleared the lane's in-flight tide, turning every subsequent window reopen into a no-op — no disown, no worker abort, no demand carry-over — while the wave kept publishing against the pre-reopen snapshot. The `final_chunk_seen` field was designed as the guard and never read. Fixed (gate = final chunk AND drained queue) with a multi-turn pump regression test that fails on the old gate.
- **MAJOR — cone seeding trusted a possibly-stale reverse index.** Presence of a changed url in the index narrowed the demand even when its rev-set predated a just-added importer. The memo now carries a tide-ledger epoch stamp; seeding widens to `All` whenever a corpus-shaping input mark advanced past it. Widen, never guess; regression test pinned.
- MINOR: eviction sweep amortized to shard creations only (stable addresses cannot grow on overwrite); the full-workspace reference arm now resolves targets through the same demand-shaped routine as the flush path; const assert pins the footprint bitset width.
- Reviewer verdicts elsewhere: generation arithmetic CLEAN (monotone, no ABA), verifying-trace path vocabulary CLEAN (mismatch degrades to fail-soft miss, never an unsound serve), kernel purity and feature graph CLEAN. Known NIT kept: the streaming collector ignores emit() backpressure after the receiver drops (shutdown path only).
